### PR TITLE
infra: Mark intermediate_output functional tests as xfail if not run on Linux

### DIFF
--- a/test/functional/test_intermediate_output.py
+++ b/test/functional/test_intermediate_output.py
@@ -13,11 +13,13 @@
 from __future__ import absolute_import
 
 import os
+import platform
 import time
 
 import boto3
 from botocore.exceptions import ClientError
 import numpy as np
+import pytest
 
 from sagemaker_training import env, files, intermediate_output
 import test
@@ -32,6 +34,13 @@ def _timestamp():
     return time.strftime("%Y-%m-%d-%H-%M-%S".format(time.gmtime(time.time())))
 
 
+@pytest.mark.xfail(
+    platform.system() != "Linux",
+    reason="""
+    intermediate_output.start_sync depends on inotify, which is a Linux kernel subsystem
+    and is not available on macOS or Windows.
+    """,
+)
 def test_intermediate_upload():
     os.environ["TRAINING_JOB_NAME"] = _timestamp()
     p = intermediate_output.start_sync(bucket_uri, region)
@@ -140,6 +149,13 @@ def test_intermediate_upload():
         assert content == content_to_assert
 
 
+@pytest.mark.xfail(
+    platform.system() != "Linux",
+    reason="""
+    intermediate_output.start_sync depends on inotify, which is a Linux kernel subsystem
+    and is not available on macOS or Windows.
+    """,
+)
 def test_nested_delayed_file():
     os.environ["TRAINING_JOB_NAME"] = _timestamp()
     p = intermediate_output.start_sync(bucket_uri, region)
@@ -183,6 +199,13 @@ def test_nested_delayed_file():
     )
 
 
+@pytest.mark.xfail(
+    platform.system() != "Linux",
+    reason="""
+    intermediate_output.start_sync depends on inotify, which is a Linux kernel subsystem
+    and is not available on macOS or Windows.
+    """,
+)
 def test_large_files():
     os.environ["TRAINING_JOB_NAME"] = _timestamp()
     p = intermediate_output.start_sync(bucket_uri, region)


### PR DESCRIPTION
*Description of changes:*
- When running the functional tests locally on a macOS or Windows machine, the `intermediate_output` functional tests will always fail. This is because the `intermediate_output.start_sync` function depends on [`inotify`](http://man7.org/linux/man-pages/man7/inotify.7.html), which is a Linux kernel subsystem and is not available on macOS or Windows.
- This change marks the appropriate tests as expected to fail if run on a platform other than Linux.

*Testing done:*
- Ran the functional tests locally (on macOS) and the appropriate tests xfailed:
    - `test/functional/test_intermediate_output.py xxx`
- Checked the PR build in CodeBuild (running Linux) and the appropriate tests passed:
    - `test/functional/test_intermediate_output.py ...`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
