### PR TITLE
infra: Set IS_CODEBUILD_IMAGE env variable in buildspecs

### DIFF
--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -3,6 +3,9 @@ version: 0.2
 phases:
   build:
     commands:
+      # set environment variables
+      - export IS_CODEBUILD_IMAGE="true"
+
       # prepare the release (update versions, changelog etc.)
       - git-release --prepare
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,6 +3,9 @@ version: 0.2
 phases:
   build:
     commands:
+      # set environment variables
+      - export IS_CODEBUILD_IMAGE="true"
+
       # run linters
       - TOX_PARALLEL_NO_SPINNER=1
       - tox -e flake8,black-check,pylint --parallel all


### PR DESCRIPTION
*Description of changes:*
- In https://github.com/aws/sagemaker-training-toolkit/commit/78ab99868d1e96eab9b6210f99a3bb26ab37afe9 the `gethostname` tests were marked as expected to fail if not run on CodeBuild, but the expected environment variable on CodeBuild was not set.
- This change adds the `IS_CODEBUILD_IMAGE` environment variable to the appropriate buildspecs.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
