### PR TITLE
feature: Add Python 3.7 support

### DIFF
--- a/.coveragerc_py37
+++ b/.coveragerc_py37
@@ -1,0 +1,20 @@
+[run]
+branch = True
+timid = True
+
+[report]
+exclude_lines =
+    pragma: no cover
+    pragma: py3 no cover
+    if six.PY2
+    elif six.PY2
+
+partial_branches =
+    pragma: no cover
+    pragma: py3 no cover
+    if six.PY3
+    elif six.PY3
+
+show_missing = True
+
+fail_under = 90

--- a/test/functional/test_training_framework.py
+++ b/test/functional/test_training_framework.py
@@ -85,7 +85,7 @@ def save(model, model_dir):
 """
 
 USER_SCRIPT_WITH_EXCEPTION = """
-import errno 
+import errno
 
 def train(channel_input_dirs, hyperparameters):
     raise OSError(errno.ENOENT, 'No such file or directory')

--- a/test/functional/test_training_framework.py
+++ b/test/functional/test_training_framework.py
@@ -85,10 +85,10 @@ def save(model, model_dir):
 """
 
 USER_SCRIPT_WITH_EXCEPTION = """
-import os
+import errno 
 
 def train(channel_input_dirs, hyperparameters):
-    raise OSError(os.errno.ENOENT, 'No such file or directory')
+    raise OSError(errno.ENOENT, 'No such file or directory')
 """
 
 MPI_USER_MODE_SCRIPT_BASIC = """

--- a/test/unit/test_trainer.py
+++ b/test/unit/test_trainer.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import errno
-import os
 
 from mock import MagicMock, Mock, patch
 
@@ -78,7 +77,7 @@ def test_train_with_success(_exit, import_module):
 @patch("sagemaker_training.trainer._exit_processes")
 def test_train_fails(_exit, import_module):
     def fail():
-        raise OSError(os.errno.ENOENT, "No such file or directory")
+        raise OSError(errno.ENOENT, "No such file or directory")
 
     framework = Mock(entry_point=fail)
     import_module.return_value = framework
@@ -133,7 +132,7 @@ def test_train_fails_with_invalid_error_number(_exit, import_module):
 @patch("sagemaker_training.trainer._exit_processes")
 def test_train_with_client_error(_exit, import_module):
     def fail():
-        raise errors.ClientError(os.errno.ENOENT, "No such file or directory")
+        raise errors.ClientError(errno.ENOENT, "No such file or directory")
 
     framework = Mock(entry_point=fail)
     import_module.return_value = framework

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = black-format,flake8,pylint,twine,py27,py36
+envlist = black-format,flake8,pylint,twine,py27,py36,py37,py38
 
 skip_missing_interpreters = False
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = black-format,flake8,pylint,twine,py27,py36,py37,py38
+envlist = black-format,flake8,pylint,twine,py27,py36,py37
 
 skip_missing_interpreters = False
 


### PR DESCRIPTION
*Description of changes:*
- Add py37 to tox testenv list.
- Fixed errors related to `errno`.

*Testing done:*
- Ran unit, functional, and integration tests locally using `tox -e py37`.
- The CodeBuild image has not yet been updated with Python 3.7, so the buildspecs have not been modified. A future PR will update the buildspecs to run tox with py37 once the CodeBuild image has been updated.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
