### PR TITLE
fix: Remove typing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ required_packages = [
     "boto3",
     "six",
     "pip",
-    "typing",
     "retrying>=1.3.3",
     "gevent",
     "inotify_simple==1.2.1",

--- a/src/sagemaker_training/encoders.py
+++ b/src/sagemaker_training/encoders.py
@@ -16,7 +16,6 @@ from __future__ import absolute_import
 import csv
 import io
 import json
-from typing import Iterable
 
 import numpy as np
 from scipy.sparse import issparse

--- a/src/sagemaker_training/encoders.py
+++ b/src/sagemaker_training/encoders.py
@@ -28,7 +28,7 @@ from sagemaker_training.recordio import (
 )
 
 
-def array_to_npy(array_like):  # type: (np.array or Iterable or int or float) -> object
+def array_to_npy(array_like):
     """Convert an array-like object to the NPY format.
 
     To understand what an array-like object is, please see:
@@ -45,7 +45,7 @@ def array_to_npy(array_like):  # type: (np.array or Iterable or int or float) ->
     return buffer.getvalue()
 
 
-def npy_to_numpy(npy_array):  # type: (object) -> np.array
+def npy_to_numpy(npy_array):
     """Convert an NPY array into numpy.
 
     Args:
@@ -57,7 +57,7 @@ def npy_to_numpy(npy_array):  # type: (object) -> np.array
     return np.load(stream, allow_pickle=True)
 
 
-def array_to_json(array_like):  # type: (np.array or Iterable or int or float) -> str
+def array_to_json(array_like):
     """Convert an array-like object to JSON.
 
     To understand what an array-like object is, please see:
@@ -79,7 +79,7 @@ def array_to_json(array_like):  # type: (np.array or Iterable or int or float) -
     return json.dumps(array_like, default=default)
 
 
-def json_to_numpy(string_like, dtype=None):  # type: (str) -> np.array
+def json_to_numpy(string_like, dtype=None):
     """Convert a JSON object to a numpy array.
 
         Args:
@@ -97,7 +97,7 @@ def json_to_numpy(string_like, dtype=None):  # type: (str) -> np.array
     return np.array(data, dtype=dtype)
 
 
-def csv_to_numpy(string_like, dtype=None):  # type: (str) -> np.array
+def csv_to_numpy(string_like, dtype=None):
     """Convert a CSV object to a numpy array.
 
     Args:
@@ -125,7 +125,7 @@ def csv_to_numpy(string_like, dtype=None):  # type: (str) -> np.array
     return array
 
 
-def array_to_csv(array_like):  # type: (np.array or Iterable or int or float) -> str
+def array_to_csv(array_like):
     """Convert an array like object to CSV.
 
     To understand what an array-like object is, please see:
@@ -195,7 +195,6 @@ _decoders_map = {
 
 
 def decode(obj, content_type):
-    # type: (np.array or Iterable or int or float, str) -> np.array
     """Decode an object of one of the default content types to a numpy array.
 
     Args:
@@ -213,7 +212,6 @@ def decode(obj, content_type):
 
 
 def encode(array_like, content_type):
-    # type: (np.array or Iterable or int or float, str) -> np.array
     """Encode an array-like object in a specific content_type to a numpy array.
 
     To understand what an array-like object is, please see:

--- a/src/sagemaker_training/entry_point.py
+++ b/src/sagemaker_training/entry_point.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 import os
 import socket
 import sys
-from typing import Dict, List  # noqa ignore=F401 imported but unused
 
 from retrying import retry
 

--- a/src/sagemaker_training/entry_point.py
+++ b/src/sagemaker_training/entry_point.py
@@ -71,7 +71,8 @@ def run(
             a local directory, or a path to a local tarball.
         user_entry_point (str): Name of the user provided entry point.
         args ([str]):  A list of program arguments.
-        env_vars (dict(str,str)): A map containing the environment variables to be written (default: None).
+        env_vars (dict(str,str)): A map containing the environment variables to be written
+            (default: None).
         wait (bool): If the user entry point should be run to completion before this method returns
             (default: True).
         capture_error (bool): Default false. If True, the running process captures the

--- a/src/sagemaker_training/entry_point.py
+++ b/src/sagemaker_training/entry_point.py
@@ -34,7 +34,6 @@ def run(
     runner_type=runner.ProcessRunnerType,
     extra_opts=None,
 ):
-    # type: (str, str, List[str], Dict[str, str], bool, bool, runner.RunnerType,Dict[str, str]) -> None  # pylint: disable=line-too-long # noqa ignore=E501
     """Download, prepare and execute a compressed tar file from S3 or provided directory as a user
     entry point. Run the user entry point, passing env_vars as environment variables and args
     as command arguments.
@@ -71,15 +70,15 @@ def run(
         uri (str): The location of the module or script. This can be an S3 uri, a path to
             a local directory, or a path to a local tarball.
         user_entry_point (str): Name of the user provided entry point.
-        args (list):  A list of program arguments.
-        env_vars (dict): A map containing the environment variables to be written (default: None).
+        args ([str]):  A list of program arguments.
+        env_vars (dict(str,str)): A map containing the environment variables to be written (default: None).
         wait (bool): If the user entry point should be run to completion before this method returns
             (default: True).
         capture_error (bool): Default false. If True, the running process captures the
             stderr, and appends it to the returned Exception message in case of errors.
         runner_type (sagemaker_training.runner.RunnerType): The type of runner object to
             be created (default: sagemaker_training.runner.ProcessRunnerType).
-        extra_opts (dict): Additional options for running the entry point (default: None).
+        extra_opts (dict(str,str)): Additional options for running the entry point (default: None).
             Currently, this only applies for MPI.
 
     Returns:

--- a/src/sagemaker_training/functions.py
+++ b/src/sagemaker_training/functions.py
@@ -23,7 +23,7 @@ import six
 from sagemaker_training import mapping
 
 
-def matching_args(fn, dictionary):  # type: (Callable, mapping.Mapping) -> dict
+def matching_args(fn, dictionary):
     """Given a function fn and a dict dictionary, returns the function
     arguments that match the dict keys.
 
@@ -53,9 +53,7 @@ def matching_args(fn, dictionary):  # type: (Callable, mapping.Mapping) -> dict
     return mapping.split_by_criteria(dictionary, arg_spec.args).included
 
 
-def getargspec(  # pylint: disable=inconsistent-return-statements
-    fn
-):  # type: (Callable) -> inspect.ArgSpec
+def getargspec(fn):  # pylint: disable=inconsistent-return-statements
     """Get the names and default values of a function's arguments.
 
     Args:
@@ -79,7 +77,7 @@ def getargspec(  # pylint: disable=inconsistent-return-statements
         )
 
 
-def error_wrapper(fn, error_class):  # type: (Callable or None, Exception) -> ...
+def error_wrapper(fn, error_class):
     """Wraps function fn in a try catch block that re-raises error_class.
 
     Args:

--- a/src/sagemaker_training/functions.py
+++ b/src/sagemaker_training/functions.py
@@ -17,7 +17,6 @@ from __future__ import absolute_import
 
 import inspect
 import sys
-from typing import Callable
 
 import six
 

--- a/src/sagemaker_training/mpi.py
+++ b/src/sagemaker_training/mpi.py
@@ -160,7 +160,7 @@ class MasterRunner(process.ProcessRunner):
                     time.sleep(self._interval)
                 logger.info("Worker %s available for communication", host)
 
-    def _create_command(self):  # type: () -> List[str, Any]
+    def _create_command(self):
         num_hosts = len(self._hosts)
         num_processes = self._num_processes or self._process_per_host * num_hosts
 
@@ -297,7 +297,6 @@ def _can_connect(host, port=22):  # type: (str, int) -> bool
 
 
 def _parse_custom_mpi_options(custom_mpi_options):
-    # type: (str) -> Tuple[argparse.Namespace, List[str]]
     """Parse custom MPI options provided by user. Known options default value will be overridden
     and unknown options will be identified separately."""
 

--- a/src/sagemaker_training/mpi.py
+++ b/src/sagemaker_training/mpi.py
@@ -18,7 +18,6 @@ import logging
 import os
 import subprocess
 import time
-from typing import Any, List, Tuple  # noqa ignore=F401 imported but unused
 
 import paramiko
 import psutil

--- a/src/sagemaker_training/process.py
+++ b/src/sagemaker_training/process.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 import os
 import subprocess
 import sys
-from typing import Dict, List, Mapping  # noqa ignore=F401 imported but unused
 
 import six
 

--- a/src/sagemaker_training/process.py
+++ b/src/sagemaker_training/process.py
@@ -52,11 +52,10 @@ def create(cmd, error_class, cwd=None, capture_error=False, **kwargs):
 
 
 def check_error(cmd, error_class, capture_error=False, **kwargs):
-    # type: (List[str], type, bool, Mapping[str, object]) -> subprocess.Popen
     """Run a commmand, raising an exception if there is an error.
 
     Args:
-        cmd (list): The command to be run.
+        cmd ([str]): The command to be run.
         error_class (cls): The class to use when raising an exception.
         capture_error (bool): Whether or not to include stderr in
             the exception message (default: False). In either case,
@@ -100,7 +99,6 @@ class ProcessRunner(object):
     """
 
     def __init__(self, user_entry_point, args, env_vars):
-        # type: (str, List[str], Dict[str, str]) -> None
         """Initialize a ProcessRunner, which is responsible for executing the user
         entry point within a process.
 

--- a/src/sagemaker_training/runner.py
+++ b/src/sagemaker_training/runner.py
@@ -16,7 +16,6 @@ runner type.
 from __future__ import absolute_import
 
 import enum
-from typing import Dict, List  # noqa ignore=F401 imported but unused
 
 from sagemaker_training import environment, mpi, params, process
 

--- a/src/sagemaker_training/runner.py
+++ b/src/sagemaker_training/runner.py
@@ -32,7 +32,6 @@ MPIRunnerType = RunnerType.MPI
 
 
 def get(identifier, user_entry_point=None, args=None, env_vars=None, extra_opts=None):
-    # type: (RunnerType, str, List[str], Dict[str]) -> process.Runner
     """Get the process runner based on the runner type.
 
     Args:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-training-toolkit/issues/60

*Description of changes:*
- There is a known conflict between the built-in `typing` package in Python 3.7 and the backported `typing` package available through PyPI.
- Since this toolkit supports both Python 2.7 and 3.7, the `typing` PyPI dependency and all usage of `typing` have been removed.

*Testing done:*
Ran tox locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
