### PR TITLE
fix: do not install and run Python script as a module

### DIFF
--- a/src/sagemaker_training/entry_point.py
+++ b/src/sagemaker_training/entry_point.py
@@ -116,15 +116,8 @@ def install(name, path=environment.code_dir, capture_error=False):
         sys.path.insert(0, path)
 
     entry_point_type = _entry_point_type.get(path, name)
-
-    if (
-        entry_point_type is _entry_point_type.PYTHON_PACKAGE
-        or entry_point_type is _entry_point_type.PYTHON_PROGRAM
-        or modules.has_requirements(path)
-    ):
-        modules.prepare(path, name)
+    if entry_point_type is _entry_point_type.PYTHON_PACKAGE:
         modules.install(path, capture_error)
-
     if entry_point_type is _entry_point_type.COMMAND:
         os.chmod(os.path.join(path, name), 511)
 


### PR DESCRIPTION
*Description of changes:*
- `entry_point.install` installed and ran Python scripts as modules. This caused an issue with the command attempting to execute the incorrect module name.
- This change reverts the `entry_point.run` logic to execute Python scripts as normal.

*Testing done:*
Ran unit and functional tests locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
