### PR TITLE
fix: run Python script entry point as script and install from requirements.txt

### DIFF
--- a/src/sagemaker_training/entry_point.py
+++ b/src/sagemaker_training/entry_point.py
@@ -117,13 +117,10 @@ def install(name, path=environment.code_dir, capture_error=False):
 
     entry_point_type = _entry_point_type.get(path, name)
 
-    if (
-        entry_point_type is _entry_point_type.PYTHON_PACKAGE
-        or entry_point_type is _entry_point_type.PYTHON_PROGRAM
-        or modules.has_requirements(path)
-    ):
-        modules.prepare(path, name)
+    if entry_point_type is _entry_point_type.PYTHON_PACKAGE:
         modules.install(path, capture_error)
+    elif entry_point_type is _entry_point_type.PYTHON_PROGRAM and modules.has_requirements(path):
+        modules.install_requirements(path, capture_error)
 
     if entry_point_type is _entry_point_type.COMMAND:
         os.chmod(os.path.join(path, name), 511)

--- a/src/sagemaker_training/errors.py
+++ b/src/sagemaker_training/errors.py
@@ -52,6 +52,10 @@ class InstallModuleError(_CalledProcessError):
     """Error class indicating a module failed to install."""
 
 
+class InstallRequirementsError(_CalledProcessError):
+    """Error class indicating a module failed to install."""
+
+
 class ImportModuleError(ClientError):
     """Error class indicating a module failed to import."""
 

--- a/src/sagemaker_training/modules.py
+++ b/src/sagemaker_training/modules.py
@@ -137,9 +137,9 @@ def install_requirements(path, capture_error=False):  # type: (str, bool) -> Non
         capture_error (bool): Default false. If True, the running process captures the
             stderr, and appends it to the returned Exception message in case of errors.
     """
-    cmd = "%s -m pip install -r requirements.txt" % process.python_executable()
+    cmd = "{} -m pip install -r requirements.txt".format(process.python_executable())
 
-    logger.info("Installing dependencies from requirements.txt:\n%s", cmd)
+    logger.info("Installing dependencies from requirements.txt:\n{}".format(cmd))
 
     process.check_error(
         shlex.split(cmd), errors.InstallRequirementsError, cwd=path, capture_error=capture_error

--- a/src/sagemaker_training/modules.py
+++ b/src/sagemaker_training/modules.py
@@ -130,7 +130,7 @@ def install(path, capture_error=False):  # type: (str, bool) -> None
 
 
 def install_requirements(path, capture_error=False):  # type: (str, bool) -> None
-    """Install dependencies from requirements.txt the executing Python environment.
+    """Install dependencies from requirements.txt in the executing Python environment.
 
     Args:
         path (str):  Real path location of the requirements.txt file.

--- a/src/sagemaker_training/modules.py
+++ b/src/sagemaker_training/modules.py
@@ -129,6 +129,23 @@ def install(path, capture_error=False):  # type: (str, bool) -> None
     )
 
 
+def install_requirements(path, capture_error=False):  # type: (str, bool) -> None
+    """Install dependencies from requirements.txt the executing Python environment.
+
+    Args:
+        path (str):  Real path location of the requirements.txt file.
+        capture_error (bool): Default false. If True, the running process captures the
+            stderr, and appends it to the returned Exception message in case of errors.
+    """
+    cmd = "%s -m pip install -r requirements.txt" % process.python_executable()
+
+    logger.info("Installing dependencies from requirements.txt:\n%s", cmd)
+
+    process.check_error(
+        shlex.split(cmd), errors.InstallRequirementsError, cwd=path, capture_error=capture_error
+    )
+
+
 def import_module(uri, name=DEFAULT_MODULE_NAME):  # type: (str, str) -> module
     """Download, prepare and install a compressed tar file from S3 or provided directory as a
     module.

--- a/test/integration/local/test_dummy.py
+++ b/test/integration/local/test_dummy.py
@@ -47,6 +47,6 @@ def test_install_requirements(capsys):
 
     stdout = capsys.readouterr().out
 
-    assert "Installing collected packages: pyfiglet, train.py" in stdout
-    assert "Successfully installed pyfiglet-0.8.post1 train.py-1.0.0" in stdout
+    assert "Installing collected packages: pyfiglet" in stdout
+    assert "Successfully installed pyfiglet-0.8.post1" in stdout
     assert "Reporting training SUCCESS" in stdout

--- a/test/unit/test_modules.py
+++ b/test/unit/test_modules.py
@@ -77,6 +77,20 @@ def test_install(check_error):
 
 
 @patch("sagemaker_training.process.check_error", autospec=True)
+def test_install_requirements(check_error):
+    path = "c://sagemaker-pytorch-container"
+
+    cmd = [sys.executable, "-m", "pip", "install", "-r", "requirements.txt"]
+
+    with patch("os.path.exists", return_value=True):
+        modules.install_requirements(path)
+
+        check_error.assert_called_with(
+            cmd, errors.InstallRequirementsError, cwd=path, capture_error=False
+        )
+
+
+@patch("sagemaker_training.process.check_error", autospec=True)
 def test_install_fails(check_error):
     check_error.side_effect = errors.ClientError()
     with pytest.raises(errors.ClientError):


### PR DESCRIPTION
*Description of changes:*
- `entry_point.install` installed and ran Python scripts as modules. This caused an issue with the command attempting to execute the incorrect module name.
- This change instead execute Python scripts as normal while adding a command to install from `requirements.txt` to preserve `requirements.txt` support.

*Testing done:*
Ran unit, functional, and integration tests locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
