### PR TITLE
feat: persist env vars in /etc/environment for MPI processes

### DIFF
--- a/src/sagemaker_training/mpi.py
+++ b/src/sagemaker_training/mpi.py
@@ -62,6 +62,9 @@ class WorkerRunner(process.ProcessRunner):
             self._wait_master_to_start()
         logger.info("MPI Master online, creating SSH daemon.")
 
+        logger.info("Writing environment variables to /etc/environment for the MPI process.")
+        self._write_env_vars_to_file()
+
         _start_sshd_daemon()
 
         if wait:
@@ -69,6 +72,11 @@ class WorkerRunner(process.ProcessRunner):
             _wait_orted_process_to_finish()
             time.sleep(30)
         logger.info("MPI process finished.")
+
+    def _write_env_vars_to_file(self):  # type: () -> None
+        with open("/etc/environment", "a") as f:
+            for name in os.environ:
+                f.write("{}={}\n".format(name, os.environ.get(name)))
 
     def _wait_master_to_start(self):  # type: () -> None
         while not _can_connect(self._master_hostname):

--- a/src/sagemaker_training/mpi.py
+++ b/src/sagemaker_training/mpi.py
@@ -63,7 +63,7 @@ class WorkerRunner(process.ProcessRunner):
         logger.info("MPI Master online, creating SSH daemon.")
 
         logger.info("Writing environment variables to /etc/environment for the MPI process.")
-        self._write_env_vars_to_file()
+        _write_env_vars_to_file()
 
         _start_sshd_daemon()
 
@@ -73,11 +73,6 @@ class WorkerRunner(process.ProcessRunner):
             time.sleep(30)
         logger.info("MPI process finished.")
 
-    def _write_env_vars_to_file(self):  # type: () -> None
-        with open("/etc/environment", "a") as f:
-            for name in os.environ:
-                f.write("{}={}\n".format(name, os.environ.get(name)))
-
     def _wait_master_to_start(self):  # type: () -> None
         while not _can_connect(self._master_hostname):
             time.sleep(1)
@@ -85,6 +80,12 @@ class WorkerRunner(process.ProcessRunner):
     def _wait_master_to_finish(self):  # type: () -> None
         while _can_connect(self._master_hostname):
             time.sleep(30)
+
+
+def _write_env_vars_to_file():  # type: () -> None
+    with open("/etc/environment", "a") as f:
+        for name in os.environ:
+            f.write("{}={}\n".format(name, os.environ.get(name)))
 
 
 def _wait_orted_process_to_finish():  # type: () -> None


### PR DESCRIPTION
*Description of changes:*
- An environment variable `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` set by the Amazon ECS agent was not available in MPI processes.
- This change propagates environment variables to MPI processes to resolve this issue.

*Testing done:*
- Updated unit tests.
- Tested manually with the current TF 2.2 image.
- These changes will be consumed by [tensorflow-training-toolkit](https://github.com/aws/sagemaker-tensorflow-training-toolkit) and [mxnet-training-toolkit](https://github.com/aws/sagemaker-mxnet-training-toolkit), and automated integration tests will be added in those toolkits due to the dependency on Horovod.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
