### PR TITLE
fix: use '-bind-to none' flag to improve performance. 

### DIFF
--- a/src/sagemaker_training/mpi.py
+++ b/src/sagemaker_training/mpi.py
@@ -207,7 +207,7 @@ class MasterRunner(process.ProcessRunner):
             "plm_rsh_no_tree_spawn",
             "1",
             "-bind-to",
-            "socket",
+            "none",
             "-map-by",
             "slot",
             "-mca",

--- a/test/unit/test_mpi.py
+++ b/test/unit/test_mpi.py
@@ -139,7 +139,7 @@ def test_mpi_master_run(training_env, popen, policy, ssh_client, path_exists):
                 "plm_rsh_no_tree_spawn",
                 "1",
                 "-bind-to",
-                "socket",
+                "none",
                 "-map-by",
                 "slot",
                 "-mca",

--- a/test/unit/test_mpi.py
+++ b/test/unit/test_mpi.py
@@ -230,7 +230,7 @@ def test_mpi_master_run_python(
                 "plm_rsh_no_tree_spawn",
                 "1",
                 "-bind-to",
-                "socket",
+                "none",
                 "-map-by",
                 "slot",
                 "-mca",


### PR DESCRIPTION
Use '-bind-to none' flag to improve performance: 
https://horovod.readthedocs.io/en/latest/mpirun.html#run-horovod-with-open-mpi

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
