### PR TITLE
infra: use ECR-hosted image for ubuntu:16.04

### DIFF
--- a/test/container/dummy/Dockerfile
+++ b/test/container/dummy/Dockerfile
@@ -1,4 +1,4 @@
-FROM 142577830533.dkr.ecr.us-east-2.amazonaws.com/ubuntu:16.04
+FROM public.ecr.aws/ubuntu/ubuntu:20.04
 
 ARG PYTHON=python3
 ARG PIP=pip3

--- a/test/container/dummy/Dockerfile
+++ b/test/container/dummy/Dockerfile
@@ -1,4 +1,7 @@
-FROM public.ecr.aws/ubuntu/ubuntu:20.04
+FROM public.ecr.aws/lts/ubuntu:20.04
+
+# Disable prompts during package installation
+ENV DEBIAN_FRONTEND="noninteractive"
 
 ARG PYTHON=python3
 ARG PIP=pip3

--- a/test/container/dummy/Dockerfile
+++ b/test/container/dummy/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM 142577830533.dkr.ecr.us-east-2.amazonaws.com/ubuntu:16.04
 
 ARG PYTHON=python3
 ARG PIP=pip3


### PR DESCRIPTION
*Description of changes:*
From the [AWS Blog](https://aws.amazon.com/blogs/containers/advice-for-customers-dealing-with-docker-hub-rate-limits-and-a-coming-soon-announcement/):
> Docker, Inc. has announced that the Hub service will begin limiting the rate at which images are pulled under their anonymous and free plans. These limits will progressively take effect beginning November 2, 2020.
>
> There are two mitigation approaches we recommend. One, copy public images being used into a private registry such as Amazon Elastic Container Registry (ECR).

This PR copies the `ubuntu:16.04` image into ECR for use as a base image.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
