### PR TITLE
Update PyPI classifiers to include py38

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setuptools.setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     install_requires=required_packages,
     extras_require={


### PR DESCRIPTION
*Description of changes:*
Include py38 in PyPI classifier. Keeps it in parity with sagemaker SDK. Similar PR to https://github.com/aws/sagemaker-python-sdk/pull/1626

This PR will also update the badge on the central README after the next release.

*Testing done:*
Minimal tests ran on py38 environment. Shouldn't be any incompatibilities that I can think of.

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
