### PR TITLE
feature: configure IF_NAME for SMDATAPARALLEL

### DIFF
--- a/src/sagemaker_training/smdataparallel.py
+++ b/src/sagemaker_training/smdataparallel.py
@@ -174,6 +174,8 @@ class SMDataParallelRunner(process.ProcessRunner):
                     "-x",
                     "SMDATAPARALLEL_SERVER_PORT={}".format(smdataparallel_server_port),
                     "-x",
+                    "SMDATAPARALLEL_NETWORK_IF={}".format(self._network_interface_name),
+                    "-x",
                     "SAGEMAKER_INSTANCE_TYPE={}".format(instance_type),
                 ]
             )


### PR DESCRIPTION
feature: configure IF_NAME to be used by SMDATAPARALLEL

Forward SageMaker network_if_name to be used by SMDATAPARALLEL as an env variable over mpi launch

*Issue #, if available:*

*Description of changes:*
Forward SageMaker network interface configuration to Dataparallel library

*Testing done:*

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)

#### Tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
