### PR TITLE
feature: smdataparallel enable EFA RDMA flag

### DIFF
--- a/src/sagemaker_training/smdataparallel.py
+++ b/src/sagemaker_training/smdataparallel.py
@@ -161,11 +161,14 @@ class SMDataParallelRunner(process.ProcessRunner):
 
         mpirun_command.extend(additional_options)
 
+        instance_type = self._get_instance_type()
+        # Use EFA's RDMA functionality for one-sided and two-sided transfer
+        if instance_type in ["ml.p3dn.24xlarge", "ml.p4d.24xlarge"]:
+            mpirun_command.extend(["-x", "FI_EFA_USE_DEVICE_RDMA=1"])
+
         if smdataparallel_server_addr and smdataparallel_server_port:
             # in case of multi-node [distributed] training, smdataparallel_server_addr,
             # smdataparallel_server_port and interconnect_bandwidth will need to be set
-
-            instance_type = self._get_instance_type()
 
             mpirun_command.extend(
                 [

--- a/src/sagemaker_training/smdataparallel.py
+++ b/src/sagemaker_training/smdataparallel.py
@@ -163,7 +163,7 @@ class SMDataParallelRunner(process.ProcessRunner):
 
         instance_type = self._get_instance_type()
         # Use EFA's RDMA functionality for one-sided and two-sided transfer
-        if instance_type in ["ml.p3dn.24xlarge", "ml.p4d.24xlarge"]:
+        if instance_type in ["ml.p4d.24xlarge"]:
             mpirun_command.extend(["-x", "FI_EFA_USE_DEVICE_RDMA=1"])
 
         if smdataparallel_server_addr and smdataparallel_server_port:

--- a/test/unit/test_smdataparallel.py
+++ b/test/unit/test_smdataparallel.py
@@ -160,7 +160,7 @@ def test_smdataparallel_run_single_node_python(
             user_entry_point="train.py",
             args=["-v", "--lr", "35"],
             env_vars={
-                "SM_TRAINING_ENV": '{"additional_framework_parameters":{"sagemaker_instance_type":"ml.p3dn.24xlarge"}}'
+                "SM_TRAINING_ENV": '{"additional_framework_parameters":{"sagemaker_instance_type":"ml.p4d.24xlarge"}}'
             },
             master_hostname=master_hostname,
             hosts=hosts,

--- a/test/unit/test_smdataparallel.py
+++ b/test/unit/test_smdataparallel.py
@@ -159,7 +159,9 @@ def test_smdataparallel_run_single_node_python(
         smdataparallel_runner = smdataparallel.SMDataParallelRunner(
             user_entry_point="train.py",
             args=["-v", "--lr", "35"],
-            env_vars={},
+            env_vars={
+                "SM_TRAINING_ENV": '{"additional_framework_parameters":{"sagemaker_instance_type":"ml.p3dn.24xlarge"}}'
+            },
             master_hostname=master_hostname,
             hosts=hosts,
             custom_mpi_options="--verbose",
@@ -219,6 +221,8 @@ def test_smdataparallel_run_single_node_python(
                 "-x",
                 "LD_PRELOAD=%s" % inspect.getfile(gethostname),
                 "--verbose",
+                "-x",
+                "FI_EFA_USE_DEVICE_RDMA=1",
                 "smddprun",
                 "usr/bin/python3",
                 "-m",


### PR DESCRIPTION
*Description of changes:*
- Enabled the EFA's RDMA functionality for one-sided and two-sided transfer for `ml.p4d.24xlarge` instances.

*Testing done:*
- Ran the smdataparallel unit test
- Ran the TF2+MNIST smdataparallel jupyter notebook on `p3.16xlarge` and `p4d.24xlarge`, both ran successfully.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
