### PR TITLE
feature: configure IF_NAME for SMDATAPARALLEL

### DIFF
--- a/src/sagemaker_training/smdataparallel.py
+++ b/src/sagemaker_training/smdataparallel.py
@@ -174,6 +174,8 @@ class SMDataParallelRunner(process.ProcessRunner):
                     "-x",
                     "SMDATAPARALLEL_SERVER_PORT={}".format(smdataparallel_server_port),
                     "-x",
+                    "SMDATAPARALLEL_NETWORK_IF={}".format(self._network_interface_name),
+                    "-x",
                     "SAGEMAKER_INSTANCE_TYPE={}".format(instance_type),
                 ]
             )

--- a/src/sagemaker_training/smdataparallel.py
+++ b/src/sagemaker_training/smdataparallel.py
@@ -174,7 +174,7 @@ class SMDataParallelRunner(process.ProcessRunner):
                     "-x",
                     "SMDATAPARALLEL_SERVER_PORT={}".format(smdataparallel_server_port),
                     "-x",
-                    "SMDATAPARALLEL_DEVICE_NAME={}".format(self._network_interface_name),
+                    "SMDATAPARALLEL_IF_NAME={}".format(self._network_interface_name),
                     "-x",
                     "SAGEMAKER_INSTANCE_TYPE={}".format(instance_type),
                 ]

--- a/src/sagemaker_training/smdataparallel.py
+++ b/src/sagemaker_training/smdataparallel.py
@@ -174,7 +174,7 @@ class SMDataParallelRunner(process.ProcessRunner):
                     "-x",
                     "SMDATAPARALLEL_SERVER_PORT={}".format(smdataparallel_server_port),
                     "-x",
-                    "SMDATAPARALLEL_NETWORK_IF={}".format(self._network_interface_name),
+                    "SMDATAPARALLEL_DEVICE_NAME={}".format(self._network_interface_name),
                     "-x",
                     "SAGEMAKER_INSTANCE_TYPE={}".format(instance_type),
                 ]

--- a/src/sagemaker_training/smdataparallel.py
+++ b/src/sagemaker_training/smdataparallel.py
@@ -174,7 +174,7 @@ class SMDataParallelRunner(process.ProcessRunner):
                     "-x",
                     "SMDATAPARALLEL_SERVER_PORT={}".format(smdataparallel_server_port),
                     "-x",
-                    "SMDATAPARALLEL_NETWORK_IF={}".format(self._network_interface_name),
+                    "SMDATAPARALLEL_NETWORK_IF=%s" % self._network_interface_name,
                     "-x",
                     "SAGEMAKER_INSTANCE_TYPE={}".format(instance_type),
                 ]

--- a/src/sagemaker_training/smdataparallel.py
+++ b/src/sagemaker_training/smdataparallel.py
@@ -174,7 +174,7 @@ class SMDataParallelRunner(process.ProcessRunner):
                     "-x",
                     "SMDATAPARALLEL_SERVER_PORT={}".format(smdataparallel_server_port),
                     "-x",
-                    "SMDATAPARALLEL_NETWORK_IF=%s" % self._network_interface_name,
+                    "SMDATAPARALLEL_NETWORK_IF={}".format(self._network_interface_name),
                     "-x",
                     "SAGEMAKER_INSTANCE_TYPE={}".format(instance_type),
                 ]

--- a/test/unit/test_smdataparallel.py
+++ b/test/unit/test_smdataparallel.py
@@ -118,7 +118,7 @@ def test_smdataparallel_run_multi_node_python(
                 "-x",
                 "SMDATAPARALLEL_SERVER_PORT=%s" % str(smdataparallel_server_port),
                 "-x",
-                "SMDATAPARALLEL_DEVICE_NAME=%s" % network_interface_name,
+                "SMDATAPARALLEL_IF_NAME=%s" % network_interface_name,
                 "-x",
                 "SAGEMAKER_INSTANCE_TYPE=ml.p3.16xlarge",
                 "smddprun",

--- a/test/unit/test_smdataparallel.py
+++ b/test/unit/test_smdataparallel.py
@@ -118,6 +118,8 @@ def test_smdataparallel_run_multi_node_python(
                 "-x",
                 "SMDATAPARALLEL_SERVER_PORT=%s" % str(smdataparallel_server_port),
                 "-x",
+                "SMDATAPARALLEL_NETWORK_IF=%s" % network_interface_name,
+                "-x",
                 "SAGEMAKER_INSTANCE_TYPE=ml.p3.16xlarge",
                 "smddprun",
                 "usr/bin/python3",

--- a/test/unit/test_smdataparallel.py
+++ b/test/unit/test_smdataparallel.py
@@ -118,7 +118,7 @@ def test_smdataparallel_run_multi_node_python(
                 "-x",
                 "SMDATAPARALLEL_SERVER_PORT=%s" % str(smdataparallel_server_port),
                 "-x",
-                "SMDATAPARALLEL_NETWORK_IF=%s" % network_interface_name,
+                "SMDATAPARALLEL_DEVICE_NAME=%s" % network_interface_name,
                 "-x",
                 "SAGEMAKER_INSTANCE_TYPE=ml.p3.16xlarge",
                 "smddprun",


### PR DESCRIPTION
feature: configure IF_NAME to be used by SMDATAPARALLEL

Forward SageMaker network_if_name to be used by SMDATAPARALLEL as an env variable over mpi launch

Issue #, if available:

Description of changes:
Forward SageMaker network interface configuration to Dataparallel library

Testing done:

General
 I have read the CONTRIBUTING doc
 I used the commit message format described in CONTRIBUTING
Tests
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.