### PR TITLE
change: [smdataparallel] better messages to establish the SSH connection between workers

### DIFF
--- a/src/sagemaker_training/smdataparallel.py
+++ b/src/sagemaker_training/smdataparallel.py
@@ -92,7 +92,7 @@ class SMDataParallelRunner(process.ProcessRunner):
                     while not _can_connect(host):
                         time.sleep(self._interval)
                     logger.info("Worker %s available for communication", host)
-        except Exception:
+        except TimeoutError:
             logger.exception("Connection failed")
 
     def _get_mpirun_command(

--- a/src/sagemaker_training/smdataparallel.py
+++ b/src/sagemaker_training/smdataparallel.py
@@ -86,11 +86,14 @@ class SMDataParallelRunner(process.ProcessRunner):
         logger.info("Waiting for MPI workers to establish their SSH connections")
 
         workers = [host for host in self._hosts if host != self._master_hostname]
-        with timeout.timeout(seconds=self.timeout_in_seconds):
-            for host in workers:
-                while not _can_connect(host):
-                    time.sleep(self._interval)
-                logger.info("Worker %s available for communication", host)
+        try:
+            with timeout.timeout(seconds=self.timeout_in_seconds):
+                for host in workers:
+                    while not _can_connect(host):
+                        time.sleep(self._interval)
+                    logger.info("Worker %s available for communication", host)
+        except Exception:
+            logger.exception("Connection failed")
 
     def _get_mpirun_command(
         self,
@@ -321,8 +324,7 @@ def _can_connect(host, port=22):
         logger.info("Can connect to host %s at port %s", host, port)
         return True
     except Exception:  # pylint: disable=broad-except
-        logger.info("Cannot connect to host %s at port %s", host, port)
-        logger.exception("Connection failed")
+        logger.info("Cannot connect to host %s at port %s. Retrying...", host, port)
         return False
     finally:
         client.close()

--- a/src/sagemaker_training/smdataparallel.py
+++ b/src/sagemaker_training/smdataparallel.py
@@ -92,8 +92,11 @@ class SMDataParallelRunner(process.ProcessRunner):
                     while not _can_connect(host):
                         time.sleep(self._interval)
                     logger.info("Worker %s available for communication", host)
-        except TimeoutError:
-            logger.exception("Connection failed")
+        except timeout.TimeoutError:
+            logger.exception(
+                "Connection between the hosts couldn't established. Aborting the training."
+            )
+            raise
 
     def _get_mpirun_command(
         self,


### PR DESCRIPTION
*Description of changes:*
- This change provide better error/info messages to the user for socket connection establishment. The change doesn't throw the error message [Traceback] during first or subsequent attempt. It only throws the error message when it tries multiple times for socket connection and times out (default: 1 hour).

**Before**:
- You can see `Cannot connect to host algo-2 at port 22` followed by `paramiko.ssh_exception.NoValidConnectionsError: [Errno None] Unable to connect to port 22 on` on the first try and then `Can connect to host algo-2 at port 22` just after that. The error message confuses the user if the script has failed or not. But the actual reason is that the workers tries to handshake on the first attempt and if it fails, it retries again.

```
2021-04-06 23:03:28,091 sagemaker-training-toolkit INFO     Imported framework sagemaker_tensorflow_container.training
2021-04-06 23:03:28,763 sagemaker-training-toolkit INFO     Starting MPI run as worker node.
2021-04-06 23:03:28,763 sagemaker-training-toolkit INFO     Creating SSH daemon.
2021-04-06 23:03:28,771 sagemaker-training-toolkit INFO     Waiting for MPI workers to establish their SSH connections
2021-04-06 23:03:28,773 sagemaker-training-toolkit INFO     Cannot connect to host algo-2 at port 22
2021-04-06 23:03:28,773 sagemaker-training-toolkit ERROR    Connection failed
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/sagemaker_training/smdataparallel.py", line 317, in _can_connect
    client.connect(host, port=port)
  File "/usr/local/lib/python3.7/site-packages/paramiko/client.py", line 368, in connect
    raise NoValidConnectionsError(errors)
paramiko.ssh_exception.NoValidConnectionsError: [Errno None] Unable to connect to port 22 on xx.xx.xxx.xxx
2021-04-06 23:03:28,774 sagemaker-training-toolkit INFO     Connection closed
2021-04-06 23:03:29,855 paramiko.transport INFO     Authentication (publickey) successful!
2021-04-06 23:03:29,856 sagemaker-training-toolkit INFO     Can connect to host algo-2 at port 22
2021-04-06 23:03:29,856 sagemaker-training-toolkit INFO     Connection closed
2021-04-06 23:03:29,856 sagemaker-training-toolkit INFO     Worker algo-2 available for communication
```

**After: (Success)**
- You can see the sentence ` Cannot connect to host algo-2 at port 22. Retrying...` with word `Retrying...`. So it doesn't throw the error message during the socket creation attempt
```
2021-04-08 21:15:37,862 sagemaker-training-toolkit INFO     Cannot connect to host algo-2 at port 22. Retrying...
2021-04-08 21:15:37,863 sagemaker-training-toolkit INFO     Connection closed
2021-04-08 21:15:38,864 sagemaker-training-toolkit INFO     Cannot connect to host algo-2 at port 22. Retrying...
2021-04-08 21:15:38,865 sagemaker-training-toolkit INFO     Connection closed
2021-04-08 21:15:39,873 paramiko.transport INFO     Connected (version 2.0, client OpenSSH_7.6p1)
2021-04-08 21:15:39,952 paramiko.transport INFO     Authentication (publickey) successful!
2021-04-08 21:15:39,952 sagemaker-training-toolkit INFO     Can connect to host algo-2 at port 22
2021-04-08 21:15:39,952 sagemaker-training-toolkit INFO     Connection closed
2021-04-08 21:15:39,952 sagemaker-training-toolkit INFO     Worker algo-2 available for communication
```

**After: (failure)**
```
2021-04-08 22:44:19,309 sagemaker-training-toolkit INFO     Cannot connect to host algo-2 at port 22. Retrying...
2021-04-08 22:44:19,309 sagemaker-training-toolkit INFO     Connection closed
2021-04-08 22:44:20,310 sagemaker-training-toolkit INFO     Cannot connect to host algo-2 at port 22. Retrying...
2021-04-08 22:44:20,311 sagemaker-training-toolkit INFO     Connection closed
2021-04-08 22:44:21,298 sagemaker-training-toolkit ERROR    Connection between the hosts couldn't established. Aborting the training.
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/sagemaker_training/smdataparallel.py", line 93, in _wait_for_workers
    time.sleep(self._interval)
  File "/usr/local/lib/python3.7/site-packages/sagemaker_training/timeout.py", line 46, in handler
    raise TimeoutError("timed out after {} seconds".format(limit))
sagemaker_training.timeout.TimeoutError: timed out after 10 seconds
2021-04-08 22:44:21,301 sagemaker-training-toolkit ERROR    Reporting training FAILURE
2021-04-08 22:44:21,301 sagemaker-training-toolkit ERROR    framework error: 
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/sagemaker_training/trainer.py", line 85, in train
    entrypoint()
  File "/usr/local/lib/python3.7/site-packages/sagemaker_tensorflow_container/training.py", line 235, in main
    train(env, mapping.to_cmd_args(user_hyperparameters))
  File "/usr/local/lib/python3.7/site-packages/sagemaker_tensorflow_container/training.py", line 173, in train
    runner_type=runner_type,
  File "/usr/local/lib/python3.7/site-packages/sagemaker_training/entry_point.py", line 100, in run
    wait, capture_error
  File "/usr/local/lib/python3.7/site-packages/sagemaker_training/smdataparallel.py", line 261, in run
    self._setup()
  File "/usr/local/lib/python3.7/site-packages/sagemaker_training/smdataparallel.py", line 83, in _setup
    self._wait_for_workers()
  File "/usr/local/lib/python3.7/site-packages/sagemaker_training/smdataparallel.py", line 93, in _wait_for_workers
    time.sleep(self._interval)
  File "/usr/local/lib/python3.7/site-packages/sagemaker_training/timeout.py", line 46, in handler
    raise TimeoutError("timed out after {} seconds".format(limit))
sagemaker_training.timeout.TimeoutError: timed out after xx seconds
```

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
