### PR TITLE
Reverted -x FI_EFA_USE_DEVICE_RDMA=1 to fix a crash on PyTorch Datalo…

### DIFF
--- a/src/sagemaker_training/smdataparallel.py
+++ b/src/sagemaker_training/smdataparallel.py
@@ -168,9 +168,6 @@ class SMDataParallelRunner(process.ProcessRunner):
         mpirun_command.extend(additional_options)
 
         instance_type = self._get_instance_type()
-        # Use EFA's RDMA functionality for one-sided and two-sided transfer
-        if instance_type in ["ml.p4d.24xlarge"]:
-            mpirun_command.extend(["-x", "FI_EFA_USE_DEVICE_RDMA=1"])
 
         if smdataparallel_server_addr and smdataparallel_server_port:
             # in case of multi-node [distributed] training, smdataparallel_server_addr,

--- a/test/unit/test_smdataparallel.py
+++ b/test/unit/test_smdataparallel.py
@@ -221,8 +221,6 @@ def test_smdataparallel_run_single_node_python(
                 "-x",
                 "LD_PRELOAD=%s" % inspect.getfile(gethostname),
                 "--verbose",
-                "-x",
-                "FI_EFA_USE_DEVICE_RDMA=1",
                 "smddprun",
                 "usr/bin/python3",
                 "-m",


### PR DESCRIPTION
…aders for Distributed training

*Issue #, if available:*
Using `-x FI_EFA_USE_DEVICE_RDMA=1` was causing a crash with Dist Training in PyTorch when the training script had num_workers in DataLoaders > 0. 
eg stack trace from the crash : 
```
[1,50]<stderr>:[compute-st-p4d24xlarge-7:21766] Signal: Segmentation fault (11)
[1,50]<stderr>:[compute-st-p4d24xlarge-7:21766] Signal code: Address not mapped (1)
[1,50]<stderr>:[compute-st-p4d24xlarge-7:21766] Failing at address: 0x556b3a49c930
[1,50]<stderr>:[compute-st-p4d24xlarge-7:21766] [ 0] /lib/x86_64-linux-gnu/libpthread.so.0(+0x12980)[0x7f950ab97980]
[1,50]<stderr>:[compute-st-p4d24xlarge-7:21766] [ 1] /lib/x86_64-linux-gnu/libc.so.6(+0x952b3)[0x7f950a8292b3]
[1,50]<stderr>:[compute-st-p4d24xlarge-7:21766] [ 2] [1,50]<stderr>:/lib/x86_64-linux-gnu/libc.so.6(__libc_malloc+0x28d)[0x7f950a82b3cd]
```

After removing this flag, the crash is gone. 

*Description of changes:*
Revert of https://github.com/aws/sagemaker-training-toolkit/pull/101 

*Testing done:*
Tested on P4D SM with PyTorch MNIST and it ran successfully. Please find attached the log file from the run. 
[logs_pt_run.txt](https://github.com/aws/sagemaker-training-toolkit/files/6368170/logs_pt_run.txt)


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
