### PR TITLE
WIP - Allow entrypoint definition via python

### DIFF
--- a/src/sagemaker_training/trainer.py
+++ b/src/sagemaker_training/trainer.py
@@ -61,7 +61,7 @@ def _exit_processes(exit_code):  # type: (int) -> None
     sys.exit(exit_code)
 
 
-def train(framework_module: str = None):
+def train(framework_name: str = None):
     """The main function responsible for running training in the container."""
     intermediate_sync = None
     exit_code = SUCCESS_CODE
@@ -74,8 +74,8 @@ def train(framework_module: str = None):
             env.sagemaker_s3_output(), region, endpoint_url=s3_endpoint_url
         )
 
-        if framework_module:
-            framework_name, entry_point_name = framework_module.split(":")
+        if framework_name:
+            # This will call the main() function by default
 
             framework = importlib.import_module(framework_name)
 
@@ -83,7 +83,7 @@ def train(framework_module: str = None):
             # the framework to configure logging at import time.
             logging_config.configure_logger(env.log_level)
             logger.info("Imported framework %s", framework_name)
-            entrypoint = getattr(framework, entry_point_name)
+            entrypoint = getattr(framework, "main")
             entrypoint()
 
         elif env.framework_module:


### PR DESCRIPTION
The API of `sagemaker-training-toolkit` does not match that of `sagemaker-inference-toolkit` - which makes the framework awkward to use in the case where someone wants to use a single docker image for training and inference on sagemaker.

More specifically, `sagemaker-inference-toolkit` requires a python entrypoint 

This PR is a very simple change that allows for a module name to be passed to `sagemaker-training-toolkit` via python code, rather than specifying it via the environment variable `SAGEMAKER_PROGRAM`. This allows a single entrypoint to be used to call `sagemaker-inference-toolkit` or `sagemaker-training-toolkit`, and keeps the code path cleaner. 

An example entrypoint using this format:

```python

import sys
from sagemaker_inference import model_server
from sagemaker_training import trainer

import train
import serve


def main():
    if sys.argv[1] == "serve":
        model_server.start_model_server(serve.__name__)
    elif sys.argv[1] == "train":
        trainer.train(train.__name__)
    else:
        raise ValueError("Container must be run with one of [serve, train]")


if __name__ == "__main__":
    main()
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
