### PR TITLE
Switch to asyncio.create_subprocess_exec

### DIFF
--- a/src/sagemaker_training/process.py
+++ b/src/sagemaker_training/process.py
@@ -113,9 +113,8 @@ async def run_async(cmd, processes_per_host, env, cwd, stderr, **kwargs):
     Raises:
         error_class: If there is an exception raised when creating the process.
     """
-    cmd = " ".join(cmd)
-    proc = await asyncio.create_subprocess_shell(
-        cmd, env=env, cwd=cwd, stdout=PIPE, stderr=stderr, **kwargs
+    proc = await asyncio.create_subprocess_exec(
+        *cmd, env=env, cwd=cwd, stdout=PIPE, stderr=stderr, **kwargs
     )
 
     output = await asyncio.gather(

--- a/test/unit/test_mpi.py
+++ b/test/unit/test_mpi.py
@@ -106,10 +106,10 @@ def test_mpi_worker_run_no_wait(popen, ssh_client, path_exists, write_env_vars):
 @patch("os.path.exists")
 @patch("paramiko.SSHClient", new_callable=MockSSHClient)
 @patch("paramiko.AutoAddPolicy")
-@patch("asyncio.create_subprocess_shell")
+@patch("asyncio.create_subprocess_exec")
 @patch("sagemaker_training.environment.Environment")
 def test_mpi_master_run(
-    training_env, async_shell, policy, ssh_client, path_exists, async_gather, event_loop
+    training_env, async_exec, policy, ssh_client, path_exists, async_gather, event_loop
 ):
 
     with patch.dict(os.environ, clear=True):
@@ -187,17 +187,16 @@ def test_mpi_master_run(
             "-c",
             "./train.sh -v --lr 35",
         ]
-        extended_cmd = " ".join(cmd)
-        async_shell.assert_called_with(
-            extended_cmd,
+        async_exec.assert_called_with(
+            *cmd,
             env=ANY,
             cwd=environment.code_dir,
             stdout=asyncio.subprocess.PIPE,
             stderr=None,
         )
-        async_shell.assert_called_once()
+        async_exec.assert_called_once()
         async_gather.assert_called_once()
-        assert process == async_shell.return_value
+        assert process == async_exec.return_value
         path_exists.assert_called_with("/usr/sbin/sshd")
 
 
@@ -206,11 +205,11 @@ def test_mpi_master_run(
 @patch("sagemaker_training.process.python_executable", return_value="usr/bin/python3")
 @patch("paramiko.SSHClient", new_callable=MockSSHClient)
 @patch("paramiko.AutoAddPolicy")
-@patch("asyncio.create_subprocess_shell")
+@patch("asyncio.create_subprocess_exec")
 @patch("sagemaker_training.environment.Environment")
 def test_mpi_master_run_python(
     training_env,
-    async_shell,
+    async_exec,
     policy,
     ssh_client,
     python_executable,
@@ -297,16 +296,16 @@ def test_mpi_master_run_python(
             "--lr",
             "35",
         ]
-        async_shell.assert_called_with(
-            " ".join(cmd),
+        async_exec.assert_called_with(
+            *cmd,
             cwd=environment.code_dir,
             env=ANY,
             stdout=asyncio.subprocess.PIPE,
             stderr=None,
         )
-        async_shell.assert_called_once()
+        async_exec.assert_called_once()
         async_gather.assert_called_once()
-        assert process == async_shell.return_value
+        assert process == async_exec.return_value
         path_exists.assert_called_with("/usr/sbin/sshd")
 
 

--- a/test/unit/test_mpi.py
+++ b/test/unit/test_mpi.py
@@ -188,11 +188,7 @@ def test_mpi_master_run(
             "./train.sh -v --lr 35",
         ]
         async_exec.assert_called_with(
-            *cmd,
-            env=ANY,
-            cwd=environment.code_dir,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=None,
+            *cmd, env=ANY, cwd=environment.code_dir, stdout=asyncio.subprocess.PIPE, stderr=None
         )
         async_exec.assert_called_once()
         async_gather.assert_called_once()
@@ -297,11 +293,7 @@ def test_mpi_master_run_python(
             "35",
         ]
         async_exec.assert_called_with(
-            *cmd,
-            cwd=environment.code_dir,
-            env=ANY,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=None,
+            *cmd, cwd=environment.code_dir, env=ANY, stdout=asyncio.subprocess.PIPE, stderr=None
         )
         async_exec.assert_called_once()
         async_gather.assert_called_once()

--- a/test/unit/test_process.py
+++ b/test/unit/test_process.py
@@ -145,11 +145,7 @@ async def test_run_async(async_exec, async_gather):
     async_exec.assert_called_once()
     async_gather.assert_called_once()
     async_exec.assert_called_with(
-        *cmd,
-        stdout=asyncio.subprocess.PIPE,
-        env=ANY,
-        cwd=ANY,
-        stderr=asyncio.subprocess.PIPE,
+        *cmd, stdout=asyncio.subprocess.PIPE, env=ANY, cwd=ANY, stderr=asyncio.subprocess.PIPE
     )
     assert output == "test"
 

--- a/test/unit/test_process.py
+++ b/test/unit/test_process.py
@@ -129,9 +129,9 @@ def test_create_error():
 
 
 @patch("asyncio.gather", new_callable=AsyncMock1)
-@patch("asyncio.create_subprocess_shell")
+@patch("asyncio.create_subprocess_exec")
 @pytest.mark.asyncio
-async def test_run_async(async_shell, async_gather):
+async def test_run_async(async_exec, async_gather):
     processes_per_host = 2
     async_gather.return_value = "test"
     cmd = ["python3", "launcher.py", "--lr", "13"]
@@ -142,10 +142,10 @@ async def test_run_async(async_shell, async_gather):
         stderr=asyncio.subprocess.PIPE,
         cwd=environment.code_dir,
     )
-    async_shell.assert_called_once()
+    async_exec.assert_called_once()
     async_gather.assert_called_once()
-    async_shell.assert_called_with(
-        " ".join(cmd),
+    async_exec.assert_called_with(
+        *cmd,
         stdout=asyncio.subprocess.PIPE,
         env=ANY,
         cwd=ANY,
@@ -155,9 +155,9 @@ async def test_run_async(async_shell, async_gather):
 
 
 @patch("asyncio.gather", new_callable=AsyncMock1)
-@patch("asyncio.create_subprocess_shell")
+@patch("asyncio.create_subprocess_exec")
 @patch("sagemaker_training.logging_config.log_script_invocation")
-def test_run_python(log, async_shell, async_gather, entry_point_type_script, event_loop):
+def test_run_python(log, async_exec, async_gather, entry_point_type_script, event_loop):
 
     async_gather.return_value = ("stdout", "stderr")
 
@@ -168,10 +168,10 @@ def test_run_python(log, async_shell, async_gather, entry_point_type_script, eve
         assert output == "stderr"
 
     cmd = [sys.executable, "launcher.py", "--lr", "13"]
-    async_shell.assert_called_once()
+    async_exec.assert_called_once()
     async_gather.assert_called_once()
-    async_shell.assert_called_with(
-        " ".join(cmd),
+    async_exec.assert_called_with(
+        *cmd,
         cwd=environment.code_dir,
         env=os.environ,
         stderr=asyncio.subprocess.PIPE,

--- a/test/unit/test_smdataparallel.py
+++ b/test/unit/test_smdataparallel.py
@@ -34,11 +34,11 @@ class AsyncMock(MagicMock):
 @patch("sagemaker_training.process.python_executable", return_value="usr/bin/python3")
 @patch("paramiko.SSHClient", new_callable=MockSSHClient)
 @patch("paramiko.AutoAddPolicy")
-@patch("asyncio.create_subprocess_shell")
+@patch("asyncio.create_subprocess_exec")
 @patch("sagemaker_training.environment.Environment")
 def test_smdataparallel_run_multi_node_python(
     training_env,
-    async_shell,
+    async_exec,
     policy,
     ssh_client,
     python_executable,
@@ -142,16 +142,16 @@ def test_smdataparallel_run_multi_node_python(
             "--lr",
             "35",
         ]
-        async_shell.assert_called_with(
-            " ".join(cmd),
+        async_exec.assert_called_with(
+            *cmd,
             cwd=environment.code_dir,
             env=ANY,
             stderr=None,
             stdout=asyncio.subprocess.PIPE,
         )
-        async_shell.assert_called_once()
+        async_exec.assert_called_once()
         async_gather.assert_called_once()
-        assert process == async_shell.return_value
+        assert process == async_exec.return_value
         path_exists.assert_called_with("/usr/sbin/sshd")
 
 
@@ -160,11 +160,11 @@ def test_smdataparallel_run_multi_node_python(
 @patch("sagemaker_training.process.python_executable", return_value="usr/bin/python3")
 @patch("paramiko.SSHClient", new_callable=MockSSHClient)
 @patch("paramiko.AutoAddPolicy")
-@patch("asyncio.create_subprocess_shell")
+@patch("asyncio.create_subprocess_exec")
 @patch("sagemaker_training.environment.Environment")
 def test_smdataparallel_run_single_node_python(
     training_env,
-    async_shell,
+    async_exec,
     policy,
     ssh_client,
     python_executable,
@@ -255,16 +255,16 @@ def test_smdataparallel_run_single_node_python(
             "--lr",
             "35",
         ]
-        async_shell.assert_called_with(
-            " ".join(cmd),
+        async_exec.assert_called_with(
+            *cmd,
             cwd=environment.code_dir,
             env=ANY,
             stdout=asyncio.subprocess.PIPE,
             stderr=None,
         )
-        async_shell.assert_called_once()
+        async_exec.assert_called_once()
         async_gather.assert_called_once()
-        assert process == async_shell.return_value
+        assert process == async_exec.return_value
         path_exists.assert_called_with("/usr/sbin/sshd")
 
 

--- a/test/unit/test_smdataparallel.py
+++ b/test/unit/test_smdataparallel.py
@@ -143,11 +143,7 @@ def test_smdataparallel_run_multi_node_python(
             "35",
         ]
         async_exec.assert_called_with(
-            *cmd,
-            cwd=environment.code_dir,
-            env=ANY,
-            stderr=None,
-            stdout=asyncio.subprocess.PIPE,
+            *cmd, cwd=environment.code_dir, env=ANY, stderr=None, stdout=asyncio.subprocess.PIPE
         )
         async_exec.assert_called_once()
         async_gather.assert_called_once()
@@ -256,11 +252,7 @@ def test_smdataparallel_run_single_node_python(
             "35",
         ]
         async_exec.assert_called_with(
-            *cmd,
-            cwd=environment.code_dir,
-            env=ANY,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=None,
+            *cmd, cwd=environment.code_dir, env=ANY, stdout=asyncio.subprocess.PIPE, stderr=None
         )
         async_exec.assert_called_once()
         async_gather.assert_called_once()


### PR DESCRIPTION
*Issue #115 

*Description of changes:*

In the routine spawning the process that executes the shell entrypoint in process.py, ``asyncio.create_subprocess_exec`` is used instead of  ``asyncio.create_subprocess_shell``. With this change, command line arguments are properly passed to the shell entrypoint. 

*Testing done:*

-  [x] Proof of concept tests with the minimal working example attached to #115.
-  [x] run unit test offline

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
