### PR TITLE
Enable custom failure logging

### DIFF
--- a/src/sagemaker_training/files.py
+++ b/src/sagemaker_training/files.py
@@ -25,7 +25,9 @@ import tempfile
 import boto3
 from six.moves.urllib import parse
 
-from sagemaker_training import environment, params
+from sagemaker_training import environment, logging_config, params
+
+logger = logging_config.get_logger()
 
 
 def write_success_file():  # type: () -> None
@@ -48,7 +50,12 @@ def write_failure_file(failure_msg):  # type: (str) -> None
         failure_msg: The description of failure.
     """
     file_path = os.path.join(environment.output_dir, "failure")
-    write_file(file_path, failure_msg)
+
+    # Write failure file only if it does not exist
+    if not os.path.exists(file_path):
+        write_file(file_path, failure_msg)
+    else:
+        logger.info("Failure file exists. Skipping creation....")
 
 
 @contextlib.contextmanager

--- a/src/sagemaker_training/process.py
+++ b/src/sagemaker_training/process.py
@@ -161,7 +161,7 @@ def create(cmd, error_class, processes_per_host, cwd=None, env=None, capture_err
         six.reraise(error_class, error_class(e), sys.exc_info()[2])
 
 
-def check_error(cmd, error_class, processes_per_host, cwd=None, capture_error=False, **kwargs):
+def check_error(cmd, error_class, processes_per_host, cwd=None, capture_error=True, **kwargs):
     """Run a commmand, raising an exception if there is an error.
 
     Args:
@@ -169,7 +169,7 @@ def check_error(cmd, error_class, processes_per_host, cwd=None, capture_error=Fa
         error_class (cls): The class to use when raising an exception.
         processes_per_host (int): Number of processes per host
         capture_error (bool): Whether or not to include stderr in
-            the exception message (default: False). In either case,
+            the exception message (default: True). In either case,
             stderr is streamed to the process's output.
         **kwargs: Extra arguments that are passed to the subprocess.Popen constructor.
 

--- a/src/sagemaker_training/trainer.py
+++ b/src/sagemaker_training/trainer.py
@@ -103,11 +103,11 @@ def train():
         files.write_success_file()
     except errors.ClientError as e:
 
-        failure_message = str(e)
-        files.write_failure_file(failure_message)
+        failure_msg = str(e)
+        files.write_failure_file(failure_msg)
         logger.error("Reporting training FAILURE")
 
-        logger.error(failure_message)
+        logger.error(failure_msg)
 
         if intermediate_sync:
             intermediate_sync.join()

--- a/test/unit/test_process.py
+++ b/test/unit/test_process.py
@@ -32,11 +32,6 @@ class AsyncMock1(MagicMock):
         return super(AsyncMock1, self).__call__(*args, **kwargs)
 
 
-class AsyncMock2(MagicMock):
-    async def __call__(self, *args, **kwargs):
-        return super(AsyncMock1, self).__call__(*args, **kwargs)
-
-
 @pytest.fixture
 def entry_point_type_module():
     with patch("os.listdir", lambda x: ("setup.py",)):
@@ -66,7 +61,9 @@ def test_check_error(popen):
     test_process = MagicMock(wait=MagicMock(return_value=0))
     popen.return_value = test_process
 
-    assert test_process == process.check_error(["run"], errors.ExecuteUserScriptError, 1)
+    assert test_process == process.check_error(
+        ["run"], errors.ExecuteUserScriptError, 1, capture_error=False
+    )
 
 
 @patch("subprocess.Popen")


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-training-toolkit/issues/111

*Description of changes:*
The current state of SM Training toolkit doesn't allow users to write their own custom failure messages in the failure file. This PR fixes this issue by allowing users to do the above. Also, we have made capture error to True by default.
*Testing done:*
Unit tests and Integration tests passed locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
