### PR TITLE
fix: missing args when shell script is used

### DIFF
--- a/src/sagemaker_training/process.py
+++ b/src/sagemaker_training/process.py
@@ -193,6 +193,8 @@ def check_error(cmd, error_class, processes_per_host, cwd=None, capture_error=Tr
         stderr = output[1]
     else:
         stderr = None
+        # remove extra quotes for subprocess.Popen
+        cmd[-1] = cmd[-1].strip('"')
         process = subprocess.Popen(
             cmd, env=os.environ, cwd=cwd or environment.code_dir, stderr=stderr, **kwargs
         )
@@ -253,7 +255,7 @@ class ProcessRunner(object):
                 six.moves.shlex_quote(arg)  # pylint: disable=too-many-function-args
                 for arg in self._args
             ]
-            return ["/bin/sh", "-c", "./%s %s" % (self._user_entry_point, " ".join(args))]
+            return ["/bin/sh", "-c", '"./%s %s"' % (self._user_entry_point, " ".join(args))]
 
     def _python_command(self):  # pylint: disable=no-self-use
         return [python_executable()]

--- a/test/unit/test_mpi.py
+++ b/test/unit/test_mpi.py
@@ -185,7 +185,7 @@ def test_mpi_master_run(
             "LD_CONFIG_PATH",
             "/bin/sh",
             "-c",
-            "./train.sh -v --lr 35",
+            '"./train.sh -v --lr 35"',
         ]
         extended_cmd = " ".join(cmd)
         async_shell.assert_called_with(


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-training-toolkit/issues/119
https://github.com/aws/sagemaker-training-toolkit/issues/115

*Description of changes:*
The process launcher has been moved from `subprocess.Popen` to `asyncio.create_subprocess_shell` starting `v3.9.3`. Due to the behavior of how both of these accept the input command, we need to wrap the shell command in extra pair of quotes to ensure that `bash -c` honors the args passed to the bash script.

But these extra pair of quotes would be a problem for `subprocess.Popen` so had to remove them before launching the process through it.

*Testing done:*
All unit and formatting test cases passed.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
