### PR TITLE
fix: fix flaky issue with incorrect rc being given

### DIFF
--- a/src/sagemaker_training/process.py
+++ b/src/sagemaker_training/process.py
@@ -121,7 +121,7 @@ async def run_async(cmd, processes_per_host, env, cwd, stderr, **kwargs):
     output = await asyncio.gather(
         watch(proc.stdout, processes_per_host), watch(proc.stderr, processes_per_host)
     )
-    return_code = proc.returncode
+    return_code = await proc.wait()
     return return_code, output, proc
 
 


### PR DESCRIPTION

*Description of changes:*
Was experiencing an issue where an exception was raised in the asyncio subprocess shell but the process was reporting the return code as 0. This modifies the `run_async` function to make use of [process.wait](https://docs.python.org/3/library/asyncio-subprocess.html#asyncio.asyncio.subprocess.Process.wait) which should ensure the process is completely finished and the correct return code is returned.

*Testing done:*
All unit and formatting test cases passed.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
