### PR TITLE
Fix none exception class issue for mpi

### DIFF
--- a/src/sagemaker_training/mpi.py
+++ b/src/sagemaker_training/mpi.py
@@ -28,6 +28,7 @@ from sagemaker_training import environment, errors, logging_config, process, tim
 logger = logging_config.get_logger()
 logging.getLogger("paramiko").setLevel(logging.INFO)
 
+
 def set_exception_classes():
     """Set exception classes"""
     exception_classes = []
@@ -43,7 +44,9 @@ def set_exception_classes():
         from smdistributed.modelparallel.torch import exceptions as torch_exceptions
 
         # list of torch exceptions SMMP wants training toolkit to catch and log
-        exception_classes += [x for x in dir(torch_exceptions) if isclass(getattr(torch_exceptions, x))]
+        exception_classes += [
+            x for x in dir(torch_exceptions) if isclass(getattr(torch_exceptions, x))
+        ]
     except ImportError:
         logger.info("No torch exception classes found in smdistributed.modelparallel.torch")
 
@@ -302,7 +305,7 @@ class MasterRunner(process.ProcessRunner):
         logging_config.log_script_invocation(cmd, self._env_vars)
 
         training_env = environment.Environment()
-        exception_classes=set_exception_classes()
+        exception_classes = set_exception_classes()
         if wait:
             process_spawned = process.check_error(
                 cmd,

--- a/src/sagemaker_training/mpi.py
+++ b/src/sagemaker_training/mpi.py
@@ -29,7 +29,7 @@ logger = logging_config.get_logger()
 logging.getLogger("paramiko").setLevel(logging.INFO)
 
 
-def set_exception_classes():
+def get_modelparallel_exception_classes():
     """Set exception classes"""
     exception_classes = []
     try:
@@ -305,7 +305,7 @@ class MasterRunner(process.ProcessRunner):
         logging_config.log_script_invocation(cmd, self._env_vars)
 
         training_env = environment.Environment()
-        exception_classes = set_exception_classes()
+        exception_classes = get_modelparallel_exception_classes()
         if wait:
             process_spawned = process.check_error(
                 cmd,

--- a/src/sagemaker_training/mpi.py
+++ b/src/sagemaker_training/mpi.py
@@ -28,12 +28,12 @@ from sagemaker_training import environment, errors, logging_config, process, tim
 logger = logging_config.get_logger()
 logging.getLogger("paramiko").setLevel(logging.INFO)
 
-exception_classes = None
+exception_classes = []
 try:
     from smdistributed.modelparallel.backend import exceptions
 
     # list of exceptions SMMP wants training toolkit to catch and log
-    exception_classes = [x for x in dir(exceptions) if isclass(getattr(exceptions, x))]
+    exception_classes += [x for x in dir(exceptions) if isclass(getattr(exceptions, x))]
 except ImportError:
     logger.info("No exception classes found in smdistributed.modelparallel.backend")
 

--- a/test/unit/test_modules.py
+++ b/test/unit/test_modules.py
@@ -196,7 +196,6 @@ def test_import_module_local_directory(
     install.assert_called_once()
 
 
-
 # Pseudo Packages for Test SMP Import
 class PseudoPackage:
     def __init__(self, exceptions=None):
@@ -223,6 +222,7 @@ class PseudoBackendException:
     def __init__(self):
         return
 
+
 # Test SMP Import
 @patch.dict(sys.modules, {"smdistributed": Mock()})
 @patch.dict(sys.modules, {"smdistributed.modelparallel": Mock()})
@@ -236,23 +236,26 @@ class PseudoBackendException:
 def test_smp_exception_import():
     # import sagemaker_training.mpi as mpi
     from sagemaker_training import mpi
+
     exceptions = mpi.set_exception_classes()
     assert exceptions == [
         "PseudoBackendException",
         "PseudoTorchException",
     ], f"exceptions are {exceptions}"
-    
 
-@patch.dict(sys.modules, {'smdistributed': Mock()})
-@patch.dict(sys.modules, {'smdistributed.modelparallel': Mock()})
-@patch.dict(sys.modules, {'smdistributed.modelparallel.backend': PseudoPackage()})
-@patch.dict(sys.modules, {'smdistributed.modelparallel.torch': PseudoPackage(PseudoExceptionFile('torch'))})
+
+@patch.dict(sys.modules, {"smdistributed": Mock()})
+@patch.dict(sys.modules, {"smdistributed.modelparallel": Mock()})
+@patch.dict(sys.modules, {"smdistributed.modelparallel.backend": PseudoPackage()})
+@patch.dict(
+    sys.modules, {"smdistributed.modelparallel.torch": PseudoPackage(PseudoExceptionFile("torch"))}
+)
 def test_smp_exception_mport_torch_only():
 
     from sagemaker_training import mpi as mpi
 
     exceptions = mpi.set_exception_classes()
-    assert exceptions == ['PseudoTorchException']
+    assert exceptions == ["PseudoTorchException"]
 
 
 @patch.dict(sys.modules, {"smdistributed": Mock()})
@@ -262,5 +265,6 @@ def test_smp_exception_mport_torch_only():
 def test_smp_exception_import_no_exceptions():
 
     from sagemaker_training import mpi
+
     exceptions = mpi.set_exception_classes()
     assert exceptions == [errors.ExecuteUserScriptError], f"exceptions are {exceptions}"

--- a/test/unit/test_modules.py
+++ b/test/unit/test_modules.py
@@ -17,7 +17,7 @@ import os
 import sys
 import textwrap
 
-from mock import call, mock_open, patch, Mock
+from mock import call, Mock, mock_open, patch
 import pytest
 
 from sagemaker_training import environment, errors, files, modules, params

--- a/test/unit/test_modules.py
+++ b/test/unit/test_modules.py
@@ -237,7 +237,7 @@ def test_smp_exception_import():
     # import sagemaker_training.mpi as mpi
     from sagemaker_training import mpi
 
-    exceptions = mpi.set_exception_classes()
+    exceptions = mpi.get_modelparallel_exception_classes()
     assert exceptions == [
         "PseudoBackendException",
         "PseudoTorchException",
@@ -254,7 +254,7 @@ def test_smp_exception_mport_torch_only():
 
     from sagemaker_training import mpi as mpi
 
-    exceptions = mpi.set_exception_classes()
+    exceptions = mpi.get_modelparallel_exception_classes()
     assert exceptions == ["PseudoTorchException"]
 
 
@@ -266,5 +266,5 @@ def test_smp_exception_import_no_exceptions():
 
     from sagemaker_training import mpi
 
-    exceptions = mpi.set_exception_classes()
+    exceptions = mpi.get_modelparallel_exception_classes()
     assert exceptions == [errors.ExecuteUserScriptError], f"exceptions are {exceptions}"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Previously the exception_classes was set to None and will caused a issue when use the latest toolkit with previous version of DLC where there's no backend exceptions in smp. Fixing this issue.

Added tests to test_module.py to test the exception class importing. Which contains following circumstance:
1. No SMP exceptions detected 
2. Only torch SMP exception detected
3. Both torch and backend SMP exception detected
As SMP introduced backend exceptions later than torch exceptions, there wouldn't be the case when only backend exceptions detected

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
