### PR TITLE
update: protobuf version to overlap with TF requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ required_packages = [
     "werkzeug>=0.15.5",
     "paramiko>=2.4.2",
     "psutil>=5.6.7",
-    "protobuf>=3.19,<3.21",
+    "protobuf>=3.19,<3.20",
     "scipy>=1.2.2",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ required_packages = [
     "werkzeug>=0.15.5",
     "paramiko>=2.4.2",
     "psutil>=5.6.7",
-    "protobuf>=3.20,<3.21",
+    "protobuf>=3.19,<3.21",
     "scipy>=1.2.2",
 ]
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Tensorflow requires `protobuf >= 3.9.2, < 3.20` which does not overlap with this package's protobuf requirements. This will lead to a `pip check` failure and an incompatible version of protobuf for TF. 

*Testing done:*
CI

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
