### PR TITLE
fix: handle utf-8 decoding exceptions while processing std streams

### DIFF
--- a/src/sagemaker_training/process.py
+++ b/src/sagemaker_training/process.py
@@ -82,7 +82,8 @@ async def watch(stream, proc_per_host, error_classes=None):
         if not lines or lines == "":
             break
 
-        lines = lines.decode("utf-8").strip().split("\n")
+        # If `lines` contains non-utf-8 characters, replace them with �
+        lines = lines.decode("utf-8", "replace").strip().split("\n")
         for line in lines:
             err_line = line
             if "<stdout>" in line:


### PR DESCRIPTION
*Issue #, if available:*
During training, if the user script tries to write non utf-8 characters to Cloudwatch, an error is thrown because decoding fails and is not handled anywhere. This causes training to fail.

*Description of changes:*
Adding a parameter to replace unhandled characters with a ? during utf-8 decoding.
use � (U+FFFD, the official REPLACEMENT CHARACTER) for replacing.
Refer: https://docs.python.org/3.9/library/codecs.html#error-handlers

*Testing done:*
* Added unit test
* Successful runs on SageMaker after fix 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [N/A] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [N/A] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [N/A] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
