### PR TITLE
change: update distribution_instance_group for pytorch ddp

### DIFF
--- a/src/sagemaker_training/environment.py
+++ b/src/sagemaker_training/environment.py
@@ -804,6 +804,7 @@ class Environment(mapping.MappingMixin):  # pylint:disable=too-many-public-metho
             or self._additional_framework_parameters.get(
                 "sagemaker_distributed_dataparallel_enabled", False
             )
+            or self._additional_framework_parameters.get("sagemaker_pytorch_ddp_enabled", False)
             or self._additional_framework_parameters.get(
                 "sagemaker_multi_worker_mirrored_strategy_enabled", False
             )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Feature: Allow customers to launch native PTDDP jobs with `nccl` backend using a new distribution value: `{ "pytorchddp": "enabled": "true",  <other options> }}`
* [Design document](https://quip-amazon.com/XqmTAXW29Nua/Improving-Launcher-experience-on-SageMaker)
* In this PR: update distribution_instance_group to copy instance_groups value for pytorchddp as well.
* Connected PRs: 
   * https://github.com/aws/sagemaker-pytorch-training-toolkit/pull/236
   * https://github.com/aws/sagemaker-python-sdk/pull/3270
   * https://github.com/aws/deep-learning-containers/pull/2141

*Testing done:*
* Unit tests succeed

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
