### PR TITLE
relax exception type

### DIFF
--- a/src/sagemaker_training/smdataparallel.py
+++ b/src/sagemaker_training/smdataparallel.py
@@ -33,8 +33,13 @@ try:
 
     # list of exceptions SMDDP wants training toolkit to catch and log
     exception_classes = [x for x in dir(exceptions) if isclass(getattr(exceptions, x))]
-except ImportError:
-    logger.info("No exception classes found in smdistributed.dataparallel")
+# relaxed exception type in case of custom exceptions thrown during import
+except Exception:  # pylint: disable=broad-except
+    logger.info(
+        "smdistributed.dataparallel not found or "
+        "using an older version without custom exceptions."
+        "SM training toolkit will track user script error only"
+    )
     exception_classes = [errors.ExecuteUserScriptError]
 
 


### PR DESCRIPTION
When user installed a custom PyTorch binary that does not work for SMDDP, we will throw a custom error with detailed reason. Relaxing the Exception type here so training toolkit will not error out. 

Use case:
* User has custom pytorch installed in DLC, and does NOT intend to use SMDDP. Training toolkit should not throw an error when importing SMDDP.
* User has custom pytorch installed in DLC, and enabled SMDDP. Training toolkit will not raise errors, but SMDDP library will raise the error and provide detailed fix method in error message when SMDDP library is  ran and invoked.