### PR TITLE
fix: Removed version hardcoding for sagemaker test dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ deps =
     pytest-asyncio
     mock
     awslogs
-    sagemaker[local]==2.18.0
+    sagemaker[local]
     numpy
     flask
     gunicorn


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hardcoding the older version of the `sagemaker-python-sdk` required additional IAM policies to be able to access the default sagemaker bucket in tests. This change removes the hardcoding so that tests can be run with the most recent `sagemaker` version

*Testing done:*
Re-confirmed using `tox -e py38 -- test/functional `

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [x ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [x ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
