### PR TITLE
change: update num_processes_per_host for smdataparallel runner

### DIFF
--- a/test/unit/test_smdataparallel.py
+++ b/test/unit/test_smdataparallel.py
@@ -50,7 +50,7 @@ def test_smdataparallel_run_multi_node_python(
         hosts = ["algo-1", "algo-2"]
         master_hostname = hosts[0]
         num_hosts = len(hosts)
-        num_processes_per_host = 8
+        num_processes_per_host = 2
         num_processes = num_processes_per_host * num_hosts
         host_list = ["{}:{}".format(host, num_processes_per_host) for host in hosts]
         network_interface_name = "ethw3"
@@ -176,7 +176,7 @@ def test_smdataparallel_run_single_node_python(
         hosts = ["algo-1"]
         master_hostname = hosts[0]
         num_hosts = len(hosts)
-        num_processes_per_host = 8
+        num_processes_per_host = 4
         num_processes = num_processes_per_host * num_hosts
         host_list = hosts
         network_interface_name = "ethw3"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
smdataparallel runner hardcodes 8 processes per node since smddp only supported p3 and p4d instance types. Update that to read from env variables instead.

*Testing done:*
* Unit tests pass
* Custom DLC with these changes successfully runs training for g5 instances

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
