### PR TITLE
Fix: adding EFA specific setup to distributed training runner for PT-XLA

### DIFF
--- a/test/unit/test_pytorch_xla.py
+++ b/test/unit/test_pytorch_xla.py
@@ -85,6 +85,10 @@ class TestPyTorchXLARunner:
             )
             runner._check_compatibility = lambda: None
             runner._setup()
+            assert os.environ["NCCL_DEBUG"] == "info"
+            assert os.environ["NCCL_PROTO"] == "simple"
+            assert os.environ["FI_EFA_USE_DEVICE_RDMA"] == "1"
+            assert os.environ["OFI_NCCL_NIC_DUP_CONNS"] == str(num_gpus)
             assert os.environ["XRT_HOST_ORDINAL"] == str(rank)
             assert os.environ["XRT_SHARD_WORLD_SIZE"] == str(cluster_size)
             assert os.environ["XRT_WORKERS"] == "|".join(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
