### PR TITLE
fix: Improve worker nodes waiting mechanism in MPI jobs

### DIFF
--- a/src/sagemaker_training/__init__.py
+++ b/src/sagemaker_training/__init__.py
@@ -69,3 +69,13 @@ _PYTHON_ERRORS_ = [
     "OutOfRangeError",
     "InvalidArgumentError",
 ]
+
+_MPI_ERRORS_ = ["mpirun.real", "ORTE"]
+
+SM_EFA_NCCL_INSTANCES = [
+    "ml.g4dn.8xlarge",
+    "ml.g4dn.12xlarge",
+    "ml.g5.48xlarge",
+    "ml.p3dn.24xlarge",
+    "ml.p4d.24xlarge",
+]

--- a/src/sagemaker_training/process.py
+++ b/src/sagemaker_training/process.py
@@ -27,6 +27,7 @@ import six
 
 from sagemaker_training import (
     _entry_point_type,
+    _MPI_ERRORS_,
     _PYTHON_ERRORS_,
     environment,
     errors,
@@ -115,7 +116,7 @@ async def watch(stream, proc_per_host, error_classes=None):
                 if any(
                     str(err) in err_line
                     for err in (
-                        _PYTHON_ERRORS_ + error_classes
+                        _PYTHON_ERRORS_ + _MPI_ERRORS_ + error_classes
                         if isinstance(error_classes, list)
                         else [error_classes]
                     )

--- a/src/sagemaker_training/runner.py
+++ b/src/sagemaker_training/runner.py
@@ -90,6 +90,7 @@ def _get_by_runner_type(
     elif identifier is RunnerType.MPI and env.is_master:
         num_processes = _mpi_param_value(mpi_args, env, params.MPI_NUM_PROCESSES)
         custom_mpi_options = _mpi_param_value(mpi_args, env, params.MPI_CUSTOM_OPTIONS, "")
+        current_instance_type = env.current_instance_type
         return mpi.MasterRunner(
             user_entry_point,
             args,
@@ -100,10 +101,16 @@ def _get_by_runner_type(
             custom_mpi_options,
             env.network_interface_name,
             num_processes=num_processes,
+            instance_type=current_instance_type,
         )
     elif identifier is RunnerType.MPI:
         return mpi.WorkerRunner(
-            user_entry_point, args, env_vars, processes_per_host, env.master_hostname
+            user_entry_point,
+            args,
+            env_vars,
+            processes_per_host,
+            env.master_hostname,
+            env.current_host,
         )
     elif identifier is RunnerType.PyTorchXLA:
         return pytorch_xla.PyTorchXLARunner(

--- a/test/unit/test_mpi.py
+++ b/test/unit/test_mpi.py
@@ -43,40 +43,54 @@ class MockSSHClient(MagicMock):
 
 
 @patch("sagemaker_training.mpi._write_env_vars_to_file")
+@patch("sagemaker_training.mpi.logger")
 @patch("os.path.exists")
 @patch("time.sleep")
 @patch("paramiko.SSHClient", new_callable=MockSSHClient)
+@patch("sagemaker_training.mpi._on_terminate")
 @patch("psutil.wait_procs")
 @patch("psutil.process_iter")
 @patch("paramiko.AutoAddPolicy")
 @patch("subprocess.Popen")
 def test_mpi_worker_run(
-    popen, policy, process_iter, wait_procs, ssh_client, sleep, path_exists, write_env_vars
+    popen,
+    policy,
+    process_iter,
+    wait_procs,
+    on_terminate,
+    ssh_client,
+    sleep,
+    path_exists,
+    logger,
+    write_env_vars,
 ):
 
     process = MagicMock(info={"name": "orted"})
     process_iter.side_effect = lambda attrs: [process]
-
+    wait_procs.return_value = (process, None)
+    path_exists.side_effect = [True, False, True]
     worker = mpi.WorkerRunner(
         user_entry_point="train.sh",
         args=["-v", "--lr", "35"],
         env_vars={"LD_CONFIG_PATH": "/etc/ld"},
         processes_per_host="1",
         master_hostname="algo-1",
+        current_host="algo-2",
     )
 
     worker.run()
-
     write_env_vars.assert_called_once()
 
     ssh_client().load_system_host_keys.assert_called()
     ssh_client().set_missing_host_key_policy.assert_called_with(policy())
     ssh_client().connect.assert_called_with("algo-1", port=22)
     ssh_client().close.assert_called()
-    wait_procs.assert_called_with([process])
+    wait_procs.assert_called_with([process], callback=on_terminate)
 
     popen.assert_called_with(["/usr/sbin/sshd", "-D"])
-    path_exists.assert_called_with("/usr/sbin/sshd")
+    path_exists.call_count == 2
+    path_exists.return_value = True
+    logger.info.assert_called_with("MPI process finished.")
 
 
 @patch("sagemaker_training.mpi._write_env_vars_to_file")
@@ -90,6 +104,7 @@ def test_mpi_worker_run_no_wait(popen, ssh_client, path_exists, write_env_vars):
         env_vars={"LD_CONFIG_PATH": "/etc/ld"},
         processes_per_host=1,
         master_hostname="algo-1",
+        current_host="algo-2",
     )
 
     worker.run(wait=False)
@@ -108,8 +123,16 @@ def test_mpi_worker_run_no_wait(popen, ssh_client, path_exists, write_env_vars):
 @patch("paramiko.AutoAddPolicy")
 @patch("asyncio.create_subprocess_shell")
 @patch("sagemaker_training.environment.Environment")
+@patch("subprocess.run")
 def test_mpi_master_run(
-    training_env, async_shell, policy, ssh_client, path_exists, async_gather, event_loop
+    subprocess_run,
+    training_env,
+    async_shell,
+    policy,
+    ssh_client,
+    path_exists,
+    async_gather,
+    event_loop,
 ):
 
     with patch.dict(os.environ, clear=True):
@@ -199,6 +222,7 @@ def test_mpi_master_run(
         async_gather.assert_called_once()
         assert process == async_shell.return_value
         path_exists.assert_called_with("/usr/sbin/sshd")
+        subprocess_run.assert_called_once()
 
 
 @patch("asyncio.gather", new_callable=AsyncMock)
@@ -208,7 +232,9 @@ def test_mpi_master_run(
 @patch("paramiko.AutoAddPolicy")
 @patch("asyncio.create_subprocess_shell")
 @patch("sagemaker_training.environment.Environment")
+@patch("sagemaker_training.mpi._write_status_file")
 def test_mpi_master_run_python(
+    write_status_file,
     training_env,
     async_shell,
     policy,
@@ -308,6 +334,124 @@ def test_mpi_master_run_python(
         async_gather.assert_called_once()
         assert process == async_shell.return_value
         path_exists.assert_called_with("/usr/sbin/sshd")
+        write_status_file.assert_called_once()
+        write_status_file.assert_called_with("algo-2", "/tmp/done.algo-1")
+
+
+@patch("asyncio.gather", new_callable=AsyncMock)
+@patch("os.path.exists")
+@patch("sagemaker_training.process.python_executable", return_value="usr/bin/python3")
+@patch("paramiko.SSHClient", new_callable=MockSSHClient)
+@patch("paramiko.AutoAddPolicy")
+@patch("asyncio.create_subprocess_shell")
+@patch("sagemaker_training.environment.Environment")
+def test_mpi_master_run_python_efa(
+    training_env,
+    async_shell,
+    policy,
+    ssh_client,
+    python_executable,
+    path_exists,
+    async_gather,
+    event_loop,
+):
+
+    with patch.dict(os.environ, clear=True):
+
+        master = mpi.MasterRunner(
+            user_entry_point="train.py",
+            args=["-v", "--lr", "35"],
+            env_vars={"LD_CONFIG_PATH": "/etc/ld"},
+            master_hostname="algo-1",
+            hosts=["algo-1", "algo-2"],
+            processes_per_host=2,
+            custom_mpi_options="-v --lr 35",
+            network_interface_name="ethw3",
+            instance_type="ml.p4d.24xlarge",
+        )
+
+        process = master.run(wait=False)
+
+        ssh_client().load_system_host_keys.assert_called()
+        ssh_client().set_missing_host_key_policy.assert_called_with(policy())
+        ssh_client().connect.assert_called_with("algo-2", port=22)
+        ssh_client().close.assert_called()
+        cmd = [
+            "mpirun",
+            "--host",
+            "algo-1:2,algo-2:2",
+            "-np",
+            "4",
+            "--allow-run-as-root",
+            "--display-map",
+            "--tag-output",
+            "-mca",
+            "btl_tcp_if_include",
+            "ethw3",
+            "-mca",
+            "oob_tcp_if_include",
+            "ethw3",
+            "-mca",
+            "plm_rsh_no_tree_spawn",
+            "1",
+            "-bind-to",
+            "none",
+            "-map-by",
+            "slot",
+            "-mca",
+            "pml",
+            "ob1",
+            "-mca",
+            "btl",
+            "^openib",
+            "-mca",
+            "orte_abort_on_non_zero_status",
+            "1",
+            "-mca",
+            "btl_vader_single_copy_mechanism",
+            "none",
+            "-x",
+            "NCCL_MIN_NRINGS=4",
+            "-x",
+            "NCCL_SOCKET_IFNAME=ethw3",
+            "-x",
+            "NCCL_DEBUG=INFO",
+            "-x",
+            "LD_LIBRARY_PATH",
+            "-x",
+            "PATH",
+            "-x",
+            "LD_PRELOAD=%s" % inspect.getfile(gethostname),
+            "-v",
+            "--lr",
+            "35",
+            "-x",
+            "FI_PROVIDER=efa",
+            "-x",
+            "FI_EFA_USE_DEVICE_RDMA=1",
+            "-x",
+            "NCCL_PROTO=simple",
+            "-x",
+            "LD_CONFIG_PATH",
+            "usr/bin/python3",
+            "-m",
+            "mpi4py",
+            "train.py",
+            "-v",
+            "--lr",
+            "35",
+        ]
+        async_shell.assert_called_with(
+            " ".join(cmd),
+            cwd=environment.code_dir,
+            env=ANY,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=None,
+        )
+        async_shell.assert_called_once()
+        async_gather.assert_called_once()
+        assert process == async_shell.return_value
+        path_exists.assert_called_with("/usr/sbin/sshd")
 
 
 @patch("sagemaker_training.logging_config.log_script_invocation")
@@ -315,4 +459,4 @@ def test_connection(log):
     with pytest.raises(Exception):
         mpi._can_connect("test_host")
         log.assert_called_with("Cannot connect to host test_host")
-        log.assert_called_with("Connection failed with exceptio: ")
+        log.assert_called_with("Connection failed with exception: ")

--- a/test/unit/test_smdataparallel.py
+++ b/test/unit/test_smdataparallel.py
@@ -36,7 +36,9 @@ class AsyncMock(MagicMock):
 @patch("paramiko.AutoAddPolicy")
 @patch("asyncio.create_subprocess_shell")
 @patch("sagemaker_training.environment.Environment")
+@patch("subprocess.run")
 def test_smdataparallel_run_multi_node_python(
+    subprocess_run,
     training_env,
     async_shell,
     policy,
@@ -153,6 +155,7 @@ def test_smdataparallel_run_multi_node_python(
         async_gather.assert_called_once()
         assert process == async_shell.return_value
         path_exists.assert_called_with("/usr/sbin/sshd")
+        subprocess_run.assert_called()
 
 
 @patch("asyncio.gather", new_callable=AsyncMock)
@@ -162,7 +165,9 @@ def test_smdataparallel_run_multi_node_python(
 @patch("paramiko.AutoAddPolicy")
 @patch("asyncio.create_subprocess_shell")
 @patch("sagemaker_training.environment.Environment")
+@patch("subprocess.run")
 def test_smdataparallel_run_single_node_python(
+    subprocess_run,
     training_env,
     async_shell,
     policy,
@@ -248,6 +253,8 @@ def test_smdataparallel_run_single_node_python(
             "--verbose",
             "-x",
             "FI_EFA_USE_DEVICE_RDMA=1",
+            "-x",
+            "NCCL_PROTO=simple",
             "smddprun",
             "usr/bin/python3",
             "-m",
@@ -268,6 +275,7 @@ def test_smdataparallel_run_single_node_python(
         async_gather.assert_called_once()
         assert process == async_shell.return_value
         path_exists.assert_called_with("/usr/sbin/sshd")
+        subprocess_run.assert_not_called()
 
 
 @patch("asyncio.gather", new_callable=AsyncMock)
@@ -277,7 +285,9 @@ def test_smdataparallel_run_single_node_python(
 @patch("paramiko.AutoAddPolicy")
 @patch("asyncio.create_subprocess_shell")
 @patch("sagemaker_training.environment.Environment")
+@patch("subprocess.run")
 def test_hc_smdataparallel_run_single_node_python(
+    subprocess_run,
     training_env,
     async_shell,
     policy,
@@ -364,6 +374,8 @@ def test_hc_smdataparallel_run_single_node_python(
             "--verbose",
             "-x",
             "FI_EFA_USE_DEVICE_RDMA=1",
+            "-x",
+            "NCCL_PROTO=simple",
             "smddprun",
             "usr/bin/python3",
             "-m",
@@ -384,6 +396,7 @@ def test_hc_smdataparallel_run_single_node_python(
         async_gather.assert_called_once()
         assert process == async_shell.return_value
         path_exists.assert_called_with("/usr/sbin/sshd")
+        subprocess_run.assert_not_called()
 
 
 @patch("sagemaker_training.logging_config.log_script_invocation")


### PR DESCRIPTION
*Issue #, if available:*
ORTE has lost communication with a remote daemon
*Description of changes:*
- Made changes to the non-leader nodes to wait on `orted` process as well as look for the status file sent by the leader node.
- Added `_MPI_ERRORS_` section to the `__init__.py` to capture the MPI related errors in the console.
- Updated logic to capture `psutil.wait_procs` return values and added a callback to invoke on termination.
- updated documentation wherever needed.
- Add EFA specific flags for mpi, sm modelparallalel and dataparallel jobs.

*Testing done:*
- Updated unit tests
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
