### PR TITLE
Feature: Register tensorflow and xla exception classes to sagemaker-t…

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -32,6 +32,15 @@ phases:
       - docker build -t sagemaker-training-toolkit-test:dummy -f dummy/Dockerfile .
       - rm dummy/sagemaker_training.tar.gz
 
+      # build tensorflow container
+      - cd ../..
+      - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin 763104351884.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
+      - cp dist/sagemaker_training-*.tar.gz test/container/dummy/sagemaker_training.tar.gz
+      - cd test/container
+      - docker build -t sagemaker-training-toolkit-test:tensorflow -f tensorflow/Dockerfile .
+      #- docker tag sagemaker-training-toolkit-test:tensorflow sagemaker-training-toolkit-test:tensorflow$(($(date +%s%N)/1000000)) #append currenttime to the tag name.
+      - rm dummy/sagemaker_training.tar.gz
+      
       - cd ../..
 
       # run local integration tests

--- a/src/sagemaker_training/mpi.py
+++ b/src/sagemaker_training/mpi.py
@@ -385,6 +385,7 @@ class MasterRunner(process.ProcessRunner):
         training_env = environment.Environment()
         exception_classes = []
         exception_classes += process.get_debugger_exception_classes()
+        exception_classes += process.get_tensorflow_exception_classes()
         if training_env.is_modelparallel_enabled:
             exception_classes += get_modelparallel_exception_classes()
         # remove potential duplication

--- a/test/container/tensorflow/Dockerfile
+++ b/test/container/tensorflow/Dockerfile
@@ -1,0 +1,13 @@
+FROM 763104351884.dkr.ecr.us-west-2.amazonaws.com/tensorflow-training:2.10.0-gpu-py39-cu112-ubuntu20.04-sagemaker
+
+COPY dummy/sagemaker_training.tar.gz /sagemaker_training.tar.gz
+
+RUN ${PIP} install --no-cache-dir \
+   /sagemaker_training.tar.gz
+
+RUN rm /sagemaker_training.tar.gz
+
+COPY tensorflow/train.py /opt/ml/code/train.py
+
+ENV SAGEMAKER_PROGRAM train.py
+	

--- a/test/container/tensorflow/train.py
+++ b/test/container/tensorflow/train.py
@@ -1,0 +1,7 @@
+class XlaRuntimeError(Exception):
+    """dummy XlaRuntimeError class to throw. Unable to import the actual
+    XlaRuntimeError class defined in tensorflow/compiler/xla/python/xla_client.py module.
+    """
+
+
+raise XlaRuntimeError("Throwing the dummy exception to simulate the error.")

--- a/test/integration/local/test_tensorflow.py
+++ b/test/integration/local/test_tensorflow.py
@@ -1,0 +1,49 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import subprocess
+import sys
+
+import pytest
+from sagemaker.estimator import Estimator
+
+
+@pytest.fixture(scope="module", autouse=True)
+def container():
+    try:
+        command = (
+            "docker run --name sagemaker-training-toolkit-test "
+            "sagemaker-training-toolkit-test:tensorflow train"
+        )
+
+        proc = subprocess.Popen(command.split(), stdout=sys.stdout, stderr=subprocess.STDOUT)
+
+        yield proc.pid
+
+    finally:
+        subprocess.check_call("docker rm -f sagemaker-training-toolkit-test".split())
+
+
+def test_tensorflow_exceptions(capsys):
+    with pytest.raises(Exception):
+        estimator = Estimator(
+            image_uri="sagemaker-training-toolkit-test:tensorflow",
+            role="SageMakerRole",
+            instance_count=1,
+            instance_type="local",
+        )
+
+        estimator.fit()
+    stdout = capsys.readouterr().out
+    assert "XlaRuntimeError" in stdout

--- a/test/unit/test_modules.py
+++ b/test/unit/test_modules.py
@@ -298,3 +298,21 @@ def test_debugger_exception_import_no_exceptions():
 
     exceptions = process.get_debugger_exception_classes()
     assert exceptions == [errors.ExecuteUserScriptError], f"exceptions are {exceptions}"
+
+
+@patch.dict(sys.modules, {"tensorflow": Mock()})
+@patch.dict(sys.modules, {"tensorflow.python": Mock()})
+@patch.dict(sys.modules, {"tensorflow.python.framework": Mock()})
+@patch.dict(sys.modules, {"tensorflow.python.framework.errors_impl": Mock()})
+def test_tensorflow_exception_import():
+    from sagemaker_training import process
+
+    exceptions = process.get_tensorflow_exception_classes()
+    assert exceptions == ["XlaRuntimeError"], f"exceptions are {exceptions}"
+
+
+def test_tensorflow_exception_import_no_exceptions():
+    from sagemaker_training import process
+
+    exceptions = process.get_tensorflow_exception_classes()
+    assert exceptions == [errors.ExecuteUserScriptError], f"exceptions are {exceptions}"

--- a/test/unit/test_process.py
+++ b/test/unit/test_process.py
@@ -13,6 +13,7 @@
 from __future__ import absolute_import
 
 import asyncio
+import logging
 import os
 import sys
 
@@ -202,6 +203,13 @@ async def test_watch_debugger_error(event_loop, capsys):
     error_classes = "SMDebugError"
     output = await process.watch(stream, num_processes_per_host, error_classes=error_classes)
     assert output == expected_errmsg
+
+
+def test_get_tensorflow_exception_error(event_loop, caplog):
+    with caplog.at_level(logging.INFO):
+        process.get_tensorflow_exception_classes()
+        expected_errmsg = "Exceptions not imported for SageMaker TF as Tensorflow is not installed."
+        assert expected_errmsg in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Feature: Register tensorflow and xla exception classes to sagemaker-training-toolkit

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
