### PR TITLE
add general exception to filter

### DIFF
--- a/src/sagemaker_training/__init__.py
+++ b/src/sagemaker_training/__init__.py
@@ -14,8 +14,10 @@
 from __future__ import absolute_import
 
 # list of errors: To show user error message on the SM Training job page
-# [x for x in dir(__builtins__) if 'Error' in x]
+# [x for x in dir(__builtins__) if 'Error' in x or 'Exception' in x]
 _PYTHON_ERRORS_ = [
+    "BaseException",
+    "Exception",
     "ArithmeticError",
     "AssertionError",
     "AttributeError",


### PR DESCRIPTION
Right now the sagemaker training toolkit only log error messages if we found certain error keyword in the logs.
We are missing general exception in the filter to log error messages. 
This PR adds that, right now we are filtering (general python exceptions, MPI errors, SageMaker library specific errors).

In future, we should extend this to custom exceptions and low level/C++ exceptions.