### PR TITLE
Upgrade protobuf to prevent conflicts with smdebugger.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ required_packages = [
     "werkzeug>=0.15.5",
     "paramiko>=2.4.2",
     "psutil>=5.6.7",
-    "protobuf>=3.9.2,<3.20",
+    "protobuf>=3.9.2,<=3.20.2",
     "scipy>=1.2.2",
 ]
 


### PR DESCRIPTION
Update highest version of protobuf supported to prevent conflicts with smdebugger's dependency chain.