### PR TITLE
change: update libraries for SMDDP collectives validation

### DIFF
--- a/src/sagemaker_training/smdataparallel.py
+++ b/src/sagemaker_training/smdataparallel.py
@@ -42,8 +42,6 @@ COMMUNICATION_BACKEND_NCCL = "nccl"
 SMDDP_LIB_PATHS = [
     "/opt/conda/lib/libsmddp.so",
     "/opt/conda/lib/libsmddpcoll.so",
-    "/opt/conda/lib/liboutofband.so",
-    "/opt/conda/lib/libgloo.so",
 ]
 
 
@@ -476,9 +474,9 @@ def _validate_smddp_coll_libs_present():
     deep-learning-containers package.
 
     libsmddp.so is preloaded for training when SMDDP Collectives are used.
-    The other libraries libsmddpcoll.so, liboutofband.so and libgloo.so are
-    essential for successful training. Thus, if the libraries are absent,
-    we want to avoid training failure by disabling SMDDP Collectives.
+    The other library libsmddpcoll.so is also essential for successful training.
+    Thus, if the libraries are absent, we want to avoid training failure
+    by disabling SMDDP Collectives.
     """
     for path in SMDDP_LIB_PATHS:
         if not os.path.exists(path):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We don't need to validate for the presence of liboutofband and libgloo for SMDDP Collectives right now. Removing them from the validation check. 

*Testing done:*
* Unit tests succeed

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
