### PR TITLE
fix: SMTrainingCompilerConfigurationError takes no keyword argument

### DIFF
--- a/src/sagemaker_training/errors.py
+++ b/src/sagemaker_training/errors.py
@@ -22,10 +22,6 @@ class ClientError(Exception):
     """Error class used to separate framework and user errors."""
 
 
-class SMTrainingCompilerConfigurationError(Exception):
-    """Error class used to separate configuration errors"""
-
-
 class _CalledProcessError(ClientError):
     """This exception is raised when a process run by check_call() or
     check_output() returns a non-zero exit status.
@@ -107,3 +103,6 @@ class UnsupportedFormatError(Exception):
             % content_type
         )
         super(UnsupportedFormatError, self).__init__(self.message, **kwargs)
+
+class SMTrainingCompilerConfigurationError(_CalledProcessError):
+    """Error class used to separate configuration errors"""

--- a/src/sagemaker_training/errors.py
+++ b/src/sagemaker_training/errors.py
@@ -104,5 +104,6 @@ class UnsupportedFormatError(Exception):
         )
         super(UnsupportedFormatError, self).__init__(self.message, **kwargs)
 
+
 class SMTrainingCompilerConfigurationError(_CalledProcessError):
     """Error class used to separate configuration errors"""


### PR DESCRIPTION
*Issue #, if available:*
when the process throws internal error
https://github.com/aws/sagemaker-training-toolkit/blob/e6b857b93ff44bb5a054e0d4223486cf21ab8f10/src/sagemaker_training/process.py#L335 , it will throws ```SMTrainingCompilerConfigurationError() takes no keyword arguments``` first due to that https://github.com/aws/sagemaker-training-toolkit/blob/e6b857b93ff44bb5a054e0d4223486cf21ab8f10/src/sagemaker_training/errors.py#L25 doesn't inherit `_CalledProcessError `

*Description of changes:*

make `SMTrainingCompilerConfigurationError` inherits `_CalledProcessError `

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
