### PR TITLE
Fix: to fix SMTrainingCompilerConfigurationError handling in process.py

### DIFF
--- a/src/sagemaker_training/mpi.py
+++ b/src/sagemaker_training/mpi.py
@@ -389,7 +389,6 @@ class MasterRunner(process.ProcessRunner):
         exception_classes = []
         exception_classes += process.get_debugger_exception_classes()
         exception_classes += process.get_tensorflow_exception_classes()
-        exception_classes += process.get_trainingcompiler_exception_classes()
         if training_env.is_modelparallel_enabled:
             exception_classes += get_modelparallel_exception_classes()
         # remove potential duplication


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The code in process.py check_error assumes all errors in errors.py as sub classes of _CalledProcessError and reaises that error. Handled SMTrainingCompilerConfigurationError differently as it is not subclass of _CalledProcessError. Reverted the code of registering SMTrainingCompilerConfigurationError with toolkit ([PR](https://github.com/aws/sagemaker-training-toolkit/pull/171/files)) as SMTrainingCompilerConfigurationError can only be raised by toolkit and not the user training script.


*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [ x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [ x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
