### PR TITLE
fix: Revert SMDDP collectives feature from smdataparallel runner

### DIFF
--- a/src/sagemaker_training/smdataparallel.py
+++ b/src/sagemaker_training/smdataparallel.py
@@ -37,12 +37,6 @@ logger = logging_config.get_logger()
 logging.getLogger("paramiko").setLevel(logging.INFO)
 
 DEFAULT_ERROR_CLASS = errors.ExecuteUserScriptError
-COMMUNICATION_BACKEND_NCCL = "nccl"
-
-SMDDP_LIB_PATHS = [
-    "/opt/conda/lib/libsmddp.so",
-    "/opt/conda/lib/libsmddpcoll.so",
-]
 
 
 def get_dataparallel_exception_classes():
@@ -155,7 +149,6 @@ class SMDataParallelRunner(process.ProcessRunner):
         overridden_known_options, additional_options = _parse_custom_mpi_options(
             self._custom_mpi_options
         )
-        smddp_collectives_enabled = self.use_smddp_collectives()
 
         mpirun_command = [
             "mpirun",
@@ -235,11 +228,6 @@ class SMDataParallelRunner(process.ProcessRunner):
                 ]
             )
 
-        if smddp_collectives_enabled:
-            mpirun_command.extend(["-x", "USE_SMDDP_COLLECTIVES=1"])
-        else:
-            mpirun_command.extend(["-x", "USE_SMDDP_COLLECTIVES=0"])
-
         smddprun_command = ["smddprun"]
         mpirun_command.extend(smddprun_command)
         return mpirun_command
@@ -255,24 +243,6 @@ class SMDataParallelRunner(process.ProcessRunner):
             instance_type = sm_training_env.get("current_instance_type", None)
         logger.info("instance type: %s" % instance_type)
         return instance_type
-
-    def use_smddp_collectives(self):
-        """Check if communication_backend is set to auto.
-        If yes, enable SMDDP collectives support."""
-        sm_training_env = json.loads(self._env_vars.get("SM_TRAINING_ENV"))
-        additional_fw_params = sm_training_env.get("additional_framework_parameters")
-        if not additional_fw_params:
-            return False
-        comm_backend = additional_fw_params.get("sagemaker_communication_backend")
-        logger.info("sagemaker_communication_backend: %s" % comm_backend)
-        is_smddp_coll_installed = _validate_smddp_coll_libs_present()
-        if (
-            not comm_backend
-            or comm_backend == COMMUNICATION_BACKEND_NCCL
-            or not is_smddp_coll_installed
-        ):
-            return False
-        return True
 
     def _create_command(self):
         """Create mpi-based smddprun command.
@@ -465,28 +435,3 @@ def _parse_custom_mpi_options(custom_mpi_options):
     parser.add_argument("--NCCL_DEBUG", default="INFO", type=str)
 
     return parser.parse_known_args(custom_mpi_options.split())
-
-
-def _validate_smddp_coll_libs_present():
-    """Check if SMDDP collective communication libraries are present in the
-    container and have executable permissions. These libraries are installed in
-    SageMaker DLCs via an smddp-installer-<versions>.run file in the
-    deep-learning-containers package.
-
-    libsmddp.so is preloaded for training when SMDDP Collectives are used.
-    The other library libsmddpcoll.so is also essential for successful training.
-    Thus, if the libraries are absent, we want to avoid training failure
-    by disabling SMDDP Collectives.
-    """
-    for path in SMDDP_LIB_PATHS:
-        if not os.path.exists(path):
-            logger.warning("Missing library %s for SMDDP collective", path)
-            logger.warning(
-                "The system is not configured to run SMDDP collectives optimized"
-                "for AWS infrastructure."
-                "Please use the latest SageMaker Deep Learning Container (DLC) to "
-                "enable SMDDP Collectives support.\n"
-                "Continuing model training with default NCCL communication backend.\n"
-            )
-            return False
-    return True

--- a/test/unit/test_smdataparallel.py
+++ b/test/unit/test_smdataparallel.py
@@ -14,7 +14,6 @@ from __future__ import absolute_import
 
 import asyncio
 import inspect
-import json
 import os
 
 from mock import ANY, MagicMock, patch
@@ -65,14 +64,7 @@ def test_smdataparallel_run_multi_node_python(
             user_entry_point="train.py",
             args=["-v", "--lr", "35"],
             env_vars={
-                "SM_TRAINING_ENV": json.dumps(
-                    {
-                        "additional_framework_parameters": {
-                            "sagemaker_instance_type": "ml.p3.16xlarge",
-                            "sagemaker_communication_backend": "nccl",
-                        }
-                    }
-                ),
+                "SM_TRAINING_ENV": '{"additional_framework_parameters":{"sagemaker_instance_type":"ml.p3.16xlarge"}}'
             },
             processes_per_host=num_processes_per_host,
             master_hostname=master_hostname,
@@ -143,8 +135,6 @@ def test_smdataparallel_run_multi_node_python(
             "SMDATAPARALLEL_SERVER_PORT=%s" % str(smdataparallel_server_port),
             "-x",
             "SAGEMAKER_INSTANCE_TYPE=ml.p3.16xlarge",
-            "-x",
-            "USE_SMDDP_COLLECTIVES=0",
             "smddprun",
             "usr/bin/python3",
             "-m",
@@ -164,7 +154,7 @@ def test_smdataparallel_run_multi_node_python(
         async_shell.assert_called_once()
         async_gather.assert_called_once()
         assert process == async_shell.return_value
-        path_exists.assert_any_call("/usr/sbin/sshd")
+        path_exists.assert_called_with("/usr/sbin/sshd")
         subprocess_run.assert_called()
 
 
@@ -201,14 +191,7 @@ def test_smdataparallel_run_single_node_python(
             user_entry_point="train.py",
             args=["-v", "--lr", "35"],
             env_vars={
-                "SM_TRAINING_ENV": json.dumps(
-                    {
-                        "additional_framework_parameters": {
-                            "sagemaker_instance_type": "ml.p4d.24xlarge",
-                            "sagemaker_communication_backend": "nccl",
-                        }
-                    }
-                ),
+                "SM_TRAINING_ENV": '{"additional_framework_parameters":{"sagemaker_instance_type":"ml.p4d.24xlarge"}}'
             },
             processes_per_host=num_processes_per_host,
             master_hostname=master_hostname,
@@ -272,8 +255,6 @@ def test_smdataparallel_run_single_node_python(
             "NCCL_PROTO=simple",
             "-x",
             "FI_EFA_USE_DEVICE_RDMA=1",
-            "-x",
-            "USE_SMDDP_COLLECTIVES=0",
             "smddprun",
             "usr/bin/python3",
             "-m",
@@ -293,7 +274,7 @@ def test_smdataparallel_run_single_node_python(
         async_shell.assert_called_once()
         async_gather.assert_called_once()
         assert process == async_shell.return_value
-        path_exists.assert_any_call("/usr/sbin/sshd")
+        path_exists.assert_called_with("/usr/sbin/sshd")
         subprocess_run.assert_not_called()
 
 
@@ -330,15 +311,8 @@ def test_hc_smdataparallel_run_single_node_python(
             user_entry_point="train.py",
             args=["-v", "--lr", "35"],
             env_vars={
-                "SM_TRAINING_ENV": json.dumps(
-                    {
-                        "additional_framework_parameters": {
-                            "sagemaker_instance_type": "ml.p4d.24xlarge",
-                            "sagemaker_communication_backend": "nccl",
-                        }
-                    }
-                ),
-                "current_instance_type": "ml.p4d.24xlarge",
+                "SM_TRAINING_ENV": '{"additional_framework_parameters":{"sagemaker_distributed_dataparallel_enabled":"true"},\
+                "current_instance_type": "ml.p4d.24xlarge"}'
             },
             processes_per_host=num_processes_per_host,
             master_hostname=master_hostname,
@@ -402,8 +376,6 @@ def test_hc_smdataparallel_run_single_node_python(
             "NCCL_PROTO=simple",
             "-x",
             "FI_EFA_USE_DEVICE_RDMA=1",
-            "-x",
-            "USE_SMDDP_COLLECTIVES=0",
             "smddprun",
             "usr/bin/python3",
             "-m",
@@ -423,283 +395,8 @@ def test_hc_smdataparallel_run_single_node_python(
         async_shell.assert_called_once()
         async_gather.assert_called_once()
         assert process == async_shell.return_value
-        path_exists.assert_any_call("/usr/sbin/sshd")
+        path_exists.assert_called_with("/usr/sbin/sshd")
         subprocess_run.assert_not_called()
-
-
-@patch("asyncio.gather", new_callable=AsyncMock)
-@patch("os.path.exists")
-@patch("sagemaker_training.process.python_executable", return_value="usr/bin/python3")
-@patch("paramiko.SSHClient", new_callable=MockSSHClient)
-@patch("paramiko.AutoAddPolicy")
-@patch("asyncio.create_subprocess_shell")
-@patch("sagemaker_training.environment.Environment")
-@patch("subprocess.run")
-def test_smdataparallel_run_smddp_coll_enabled_and_installed_python(
-    subprocess_run,
-    training_env,
-    async_shell,
-    policy,
-    ssh_client,
-    python_executable,
-    path_exists,
-    async_gather,
-    event_loop,
-):
-    with patch.dict(os.environ, clear=True):
-        hosts = ["algo-1", "algo-2"]
-        master_hostname = hosts[0]
-        num_hosts = len(hosts)
-        num_processes_per_host = 2
-        num_processes = num_processes_per_host * num_hosts
-        host_list = ["{}:{}".format(host, num_processes_per_host) for host in hosts]
-        network_interface_name = "ethw3"
-        smdataparallel_server_addr = master_hostname
-        smdataparallel_server_port = 7592
-        smdataparallel_flag = "SMDATAPARALLEL_USE_HOMOGENEOUS=1"
-
-        smdataparallel_runner = smdataparallel.SMDataParallelRunner(
-            user_entry_point="train.py",
-            args=["-v", "--lr", "35"],
-            env_vars={
-                "SM_TRAINING_ENV": json.dumps(
-                    {
-                        "additional_framework_parameters": {
-                            "sagemaker_instance_type": "ml.p4d.24xlarge",
-                            "sagemaker_communication_backend": "auto",
-                        }
-                    }
-                ),
-            },
-            processes_per_host=num_processes_per_host,
-            master_hostname=master_hostname,
-            hosts=hosts,
-            custom_mpi_options="--verbose",
-            network_interface_name=network_interface_name,
-        )
-
-        _, _, process = smdataparallel_runner.run(wait=False)
-
-        ssh_client().load_system_host_keys.assert_called()
-        ssh_client().set_missing_host_key_policy.assert_called_with(policy())
-        ssh_client().connect.assert_called_with("algo-2", port=22)
-        ssh_client().close.assert_called()
-        cmd = [
-            "mpirun",
-            "--host",
-            ",".join(host_list),
-            "-np",
-            str(num_processes),
-            "--allow-run-as-root",
-            "--tag-output",
-            "--oversubscribe",
-            "-mca",
-            "btl_tcp_if_include",
-            network_interface_name,
-            "-mca",
-            "oob_tcp_if_include",
-            network_interface_name,
-            "-mca",
-            "plm_rsh_no_tree_spawn",
-            "1",
-            "-mca",
-            "pml",
-            "ob1",
-            "-mca",
-            "btl",
-            "^openib",
-            "-mca",
-            "orte_abort_on_non_zero_status",
-            "1",
-            "-mca",
-            "btl_vader_single_copy_mechanism",
-            "none",
-            "-mca",
-            "plm_rsh_num_concurrent",
-            str(num_hosts),
-            "-x",
-            "NCCL_SOCKET_IFNAME=%s" % network_interface_name,
-            "-x",
-            "NCCL_DEBUG=INFO",
-            "-x",
-            "LD_LIBRARY_PATH",
-            "-x",
-            "PATH",
-            "-x",
-            smdataparallel_flag,
-            "-x",
-            "FI_PROVIDER=efa",
-            "-x",
-            "RDMAV_FORK_SAFE=1",
-            "-x",
-            "LD_PRELOAD=%s" % inspect.getfile(gethostname),
-            "--verbose",
-            "-x",
-            "NCCL_PROTO=simple",
-            "-x",
-            "FI_EFA_USE_DEVICE_RDMA=1",
-            "-x",
-            "SMDATAPARALLEL_SERVER_ADDR=%s" % smdataparallel_server_addr,
-            "-x",
-            "SMDATAPARALLEL_SERVER_PORT=%s" % str(smdataparallel_server_port),
-            "-x",
-            "SAGEMAKER_INSTANCE_TYPE=ml.p4d.24xlarge",
-            "-x",
-            "USE_SMDDP_COLLECTIVES=1",
-            "smddprun",
-            "usr/bin/python3",
-            "-m",
-            "mpi4py",
-            "train.py",
-            "-v",
-            "--lr",
-            "35",
-        ]
-        async_shell.assert_called_with(
-            " ".join(cmd),
-            cwd=environment.code_dir,
-            env=ANY,
-            stderr=None,
-            stdout=asyncio.subprocess.PIPE,
-        )
-        async_shell.assert_called_once()
-        assert process == async_shell.return_value
-        path_exists.assert_any_call("/opt/conda/lib/libsmddp.so")
-
-
-@patch("asyncio.gather", new_callable=AsyncMock)
-@patch("sagemaker_training.process.python_executable", return_value="usr/bin/python3")
-@patch("paramiko.SSHClient", new_callable=MockSSHClient)
-@patch("paramiko.AutoAddPolicy")
-@patch("asyncio.create_subprocess_shell")
-@patch("sagemaker_training.environment.Environment")
-def test_smdataparallel_run_smddp_coll_enabled_not_installed_python(
-    training_env,
-    async_shell,
-    policy,
-    ssh_client,
-    python_executable,
-    async_gather,
-    event_loop,
-):
-    with patch.dict(os.environ, clear=True):
-        hosts = ["algo-1", "algo-2"]
-        master_hostname = hosts[0]
-        num_hosts = len(hosts)
-        num_processes_per_host = 2
-        num_processes = num_processes_per_host * num_hosts
-        host_list = ["{}:{}".format(host, num_processes_per_host) for host in hosts]
-        network_interface_name = "ethw3"
-        smdataparallel_server_addr = master_hostname
-        smdataparallel_server_port = 7592
-        smdataparallel_flag = "SMDATAPARALLEL_USE_HOMOGENEOUS=1"
-
-        smdataparallel_runner = smdataparallel.SMDataParallelRunner(
-            user_entry_point="train.py",
-            args=["-v", "--lr", "35"],
-            env_vars={
-                "SM_TRAINING_ENV": json.dumps(
-                    {
-                        "additional_framework_parameters": {
-                            "sagemaker_instance_type": "ml.p4d.24xlarge",
-                            "sagemaker_communication_backend": "auto",
-                        }
-                    }
-                ),
-            },
-            processes_per_host=num_processes_per_host,
-            master_hostname=master_hostname,
-            hosts=hosts,
-            custom_mpi_options="--verbose",
-            network_interface_name=network_interface_name,
-        )
-
-        _, _, process = smdataparallel_runner.run(wait=False)
-
-        ssh_client().load_system_host_keys.assert_called()
-        ssh_client().set_missing_host_key_policy.assert_called_with(policy())
-        ssh_client().connect.assert_called_with("algo-2", port=22)
-        ssh_client().close.assert_called()
-        cmd = [
-            "mpirun",
-            "--host",
-            ",".join(host_list),
-            "-np",
-            str(num_processes),
-            "--allow-run-as-root",
-            "--tag-output",
-            "--oversubscribe",
-            "-mca",
-            "btl_tcp_if_include",
-            network_interface_name,
-            "-mca",
-            "oob_tcp_if_include",
-            network_interface_name,
-            "-mca",
-            "plm_rsh_no_tree_spawn",
-            "1",
-            "-mca",
-            "pml",
-            "ob1",
-            "-mca",
-            "btl",
-            "^openib",
-            "-mca",
-            "orte_abort_on_non_zero_status",
-            "1",
-            "-mca",
-            "btl_vader_single_copy_mechanism",
-            "none",
-            "-mca",
-            "plm_rsh_num_concurrent",
-            str(num_hosts),
-            "-x",
-            "NCCL_SOCKET_IFNAME=%s" % network_interface_name,
-            "-x",
-            "NCCL_DEBUG=INFO",
-            "-x",
-            "LD_LIBRARY_PATH",
-            "-x",
-            "PATH",
-            "-x",
-            smdataparallel_flag,
-            "-x",
-            "FI_PROVIDER=efa",
-            "-x",
-            "RDMAV_FORK_SAFE=1",
-            "-x",
-            "LD_PRELOAD=%s" % inspect.getfile(gethostname),
-            "--verbose",
-            "-x",
-            "NCCL_PROTO=simple",
-            "-x",
-            "FI_EFA_USE_DEVICE_RDMA=1",
-            "-x",
-            "SMDATAPARALLEL_SERVER_ADDR=%s" % smdataparallel_server_addr,
-            "-x",
-            "SMDATAPARALLEL_SERVER_PORT=%s" % str(smdataparallel_server_port),
-            "-x",
-            "SAGEMAKER_INSTANCE_TYPE=ml.p4d.24xlarge",
-            "-x",
-            "USE_SMDDP_COLLECTIVES=0",
-            "smddprun",
-            "usr/bin/python3",
-            "-m",
-            "mpi4py",
-            "train.py",
-            "-v",
-            "--lr",
-            "35",
-        ]
-        async_shell.assert_called_with(
-            " ".join(cmd),
-            cwd=environment.code_dir,
-            env=ANY,
-            stderr=None,
-            stdout=asyncio.subprocess.PIPE,
-        )
-        async_shell.assert_called_once()
-        assert process == async_shell.return_value
 
 
 @patch("sagemaker_training.logging_config.log_script_invocation")


### PR DESCRIPTION
*Description of changes:*
We had added support for SMDDP collectives to smdataparallel runner via https://github.com/aws/sagemaker-training-toolkit/pull/162. We merged the toolkit changes, however due to project delays, we didn't merge the related changes in PySDK. Because of this, the warnings we added as a part of this commit are printed in `smdistributed` distribution jobs, and can be distracting/confusing to customers.
Reverting this commit so that the warnings added are not printed in unrelated scenarios.

*Testing done:*
* Unit tests succeed
* Model training with custom DLC does not print these warnings

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
