### PR TITLE
unpin sagemaker version as the credential issue fixed

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ deps =
     pytest-asyncio
     mock
     awslogs
-    sagemaker[local]==2.136.0
+    sagemaker[local]
     numpy
     flask
     gunicorn


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
While we are creating this PR: https://github.com/aws/sagemaker-training-toolkit/pull/178 to fix a connection issue in mpi, we found the newest sagemaker python sdk introduced a credential issue in SMTT pipeline, so we pined the sagemaker version 
 to v2.136.0. 
Now, the credential issue is resolved by python SDK PR: https://github.com/aws/sagemaker-python-sdk/pull/3766, and it is merged at latest version v2.145.0.

So we unpin the sagemaker version here now.
*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
