### PR TITLE
feat: support codeartifact for installing requirements.txt packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,11 +80,11 @@ setuptools.setup(
     install_requires=required_packages,
     extras_require={
         "test": [
-            "tox==3.13.1",
+            "tox==4.6.4",
             "pytest==4.4.1",
             "pytest-cov",
             "mock",
-            "sagemaker[local]<2",
+            "sagemaker[local]>=2.172.0,<3",
             "black==22.3.0 ; python_version >= '3.7'",
         ]
     },

--- a/src/sagemaker_training/modules.py
+++ b/src/sagemaker_training/modules.py
@@ -17,10 +17,12 @@ from __future__ import absolute_import
 
 import importlib
 import os
+import re
 import shlex
 import sys
 import textwrap
 
+import boto3
 import six
 
 from sagemaker_training import environment, errors, files, logging_config, process
@@ -28,6 +30,7 @@ from sagemaker_training import environment, errors, files, logging_config, proce
 logger = logging_config.get_logger()
 
 DEFAULT_MODULE_NAME = "default_user_module_name"
+CA_REPOSITORY_ARN_ENV = "CA_REPOSITORY_ARN"
 
 
 def exists(name):  # type: (str) -> bool
@@ -121,6 +124,9 @@ def install(path, capture_error=False):  # type: (str, bool) -> None
 
     if has_requirements(path):
         cmd += "-r requirements.txt"
+        if os.getenv(CA_REPOSITORY_ARN_ENV):
+            index = _get_codeartifact_index()
+            cmd += " -i {}".format(index)
 
     logger.info("Installing module with the following command:\n%s", cmd)
 
@@ -138,6 +144,9 @@ def install_requirements(path, capture_error=False):  # type: (str, bool) -> Non
             stderr, and appends it to the returned Exception message in case of errors.
     """
     cmd = "{} -m pip install -r requirements.txt".format(process.python_executable())
+    if os.getenv(CA_REPOSITORY_ARN_ENV):
+        index = _get_codeartifact_index()
+        cmd += " -i {}".format(index)
 
     logger.info("Installing dependencies from requirements.txt:\n{}".format(cmd))
 
@@ -172,3 +181,54 @@ def import_module(uri, name=DEFAULT_MODULE_NAME):  # type: (str, str) -> module
         return module
     except Exception as e:  # pylint: disable=broad-except
         six.reraise(errors.ImportModuleError, errors.ImportModuleError(e), sys.exc_info()[2])
+
+
+def _get_codeartifact_index():
+    """
+    Build the authenticated codeartifact index url based on the arn provided via CA_REPOSITORY_ARN environment variable
+    following the form `arn:${Partition}:codeartifact:${Region}:${Account}:repository/${DomainName}/${RepositoryName}`
+    https://docs.aws.amazon.com/codeartifact/latest/ug/python-configure-pip.html
+    https://docs.aws.amazon.com/service-authorization/latest/reference/list_awscodeartifact.html#awscodeartifact-resources-for-iam-policies
+    :return: authenticated codeartifact index url
+    """
+    repository_arn = os.getenv(CA_REPOSITORY_ARN_ENV)
+    arn_regex = (
+        "arn:(?P<partition>[^:]+):codeartifact:(?P<region>[^:]+):(?P<account>[^:]+)"
+        ":repository/(?P<domain>[^/]+)/(?P<repository>.+)"
+    )
+    m = re.match(arn_regex, repository_arn)
+    if not m:
+        raise Exception("invalid CodeArtifact repository arn {}".format(repository_arn))
+    domain = m.group("domain")
+    owner = m.group("account")
+    repository = m.group("repository")
+    region = m.group("region")
+
+    logger.info(
+        "configuring pip to use codeartifact "
+        "(domain: %s, domain owner: %s, repository: %s, region: %s)",
+        domain,
+        owner,
+        repository,
+        region,
+    )
+    try:
+        client = boto3.client("codeartifact", region_name=region)
+        auth_token_response = client.get_authorization_token(domain=domain, domainOwner=owner)
+        token = auth_token_response["authorizationToken"]
+        endpoint_response = client.get_repository_endpoint(
+            domain=domain, domainOwner=owner, repository=repository, format="pypi"
+        )
+        unauthenticated_index = endpoint_response["repositoryEndpoint"]
+        return re.sub(
+            "https://",
+            "https://aws:{}@".format(token),
+            re.sub(
+                "{}/?$".format(repository),
+                "{}/simple/".format(repository),
+                unauthenticated_index,
+            ),
+        )
+    except Exception:
+        logger.error("failed to configure pip to use codeartifact")
+        raise Exception("failed to configure pip to use codeartifact")

--- a/test/integration/local/test_dummy.py
+++ b/test/integration/local/test_dummy.py
@@ -50,3 +50,34 @@ def test_install_requirements(capsys):
     assert "Installing collected packages: pyfiglet" in stdout
     assert "Successfully installed pyfiglet-0.8.post1" in stdout
     assert "Reporting training SUCCESS" in stdout
+
+
+# def test_install_requirements_from_codeartifact(capsys):
+#     # TODO: fill in details for CA
+#     ca_domain = "..."
+#     ca_domain_owner = "..."
+#     ca_repository = "..."
+#     ca_region = "..."
+#     ca_repository_arn = "..."
+#
+#     estimator = Estimator(
+#         image_uri="sagemaker-training-toolkit-test:dummy",
+#         # TODO: Grant the role permissions to access CodeArtifact repo (repo resource policy + role policy)
+#         # https://docs.aws.amazon.com/codeartifact/latest/ug/security-iam.html
+#         # https://docs.aws.amazon.com/codeartifact/latest/ug/repo-policies.html
+#         role="SageMakerRole",
+#         instance_count=1,
+#         instance_type="local",
+#         environment={
+#             "CA_REPOSITORY_ARN": ca_repository_arn,
+#         }
+#     )
+#
+#     estimator.fit()
+#
+#     stdout = capsys.readouterr().out
+#
+#     assert "{}-{}.d.codeartifact.{}.amazonaws.com/pypi/{}/simple/".format(ca_domain, ca_domain_owner, ca_region, ca_repository) in stdout
+#     assert "Installing collected packages: pyfiglet" in stdout
+#     assert "Successfully installed pyfiglet-0.8.post1" in stdout
+#     assert "Reporting training SUCCESS" in stdout


### PR DESCRIPTION
*Issue #, if available:* #167

*Description of changes:*

- update modules.install_requirements to check for the presence of codeartifact (CA_* prefixed) environment variable
- if env variable is present, build the authenticated endpoint index url, and add that to the pip install command
- update sagemaker test dependency to support the setting of environment variables and update tox to resolve conflicts with newer sagemaker
- add commented out integ test for installing requirements from codeartifact

*Testing done:*

- unit tests
- commented out integ test due to infrastructure changes requirements + https://github.com/aws/sagemaker-training-toolkit/pull/187#issuecomment-1630750209

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
