### PR TITLE
fix: Add NCCL_PROTO=simple environment variable to handle the out-of-order…

### DIFF
--- a/src/sagemaker_training/torch_distributed.py
+++ b/src/sagemaker_training/torch_distributed.py
@@ -75,7 +75,9 @@ class TorchDistributedRunner(process.ProcessRunner):
         if self._instance_type in SM_EFA_RDMA_INSTANCES:
             # Use EFA's RDMA functionality for one-sided and two-sided transfer
             os.environ["FI_EFA_USE_DEVICE_RDMA"] = "1"
+            os.environ["RDMAV_FORK_SAFE"] = "1"
         os.environ["NCCL_SOCKET_IFNAME"] = str(self._network_interface_name)
+        os.environ["NCCL_PROTO"] = "simple"
 
     def _create_command(self):
         """


### PR DESCRIPTION
… data delivery from EFA

*Issue #, if available:*

*Description of changes:*
Setting NCCL_PROTO=simple explicitly to avoid data corruption errors due to out-of-order data delivery from EFA.  This variable is set automatically by the latest aws-nccl-ofi (ref: https://github.com/aws/aws-ofi-nccl/blob/3d5e21db5f2b0f307c5d0c206c4b1b66d72d0d04/src/platform-aws.c#L222C28-L222C28) but earlier versions released in previous DLCs do not.  

Also set the RDMAV_FORK_SAFE variable to be fully consistent with the environment variables set in the smdistributed launcher. 

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
