### PR TITLE
fix: use smddprun only if it is installed

### DIFF
--- a/src/sagemaker_training/environment.py
+++ b/src/sagemaker_training/environment.py
@@ -1227,6 +1227,15 @@ class Environment(mapping.MappingMixin):  # pylint:disable=too-many-public-metho
         """
         return self._is_smddpmprun_installed
 
+    @property
+    def is_smddprun_installed(self): # type: () -> bool
+        """Whether smddprun is installed.
+
+        Returns:
+            bool: True if it is installed
+        """
+        return self._is_smddprun_installed
+
 
 def write_env_vars(env_vars=None):  # type: (dict) -> None
     """Write the dictionary env_vars in the system, as environment variables.

--- a/src/sagemaker_training/environment.py
+++ b/src/sagemaker_training/environment.py
@@ -375,7 +375,7 @@ def validate_smddprun():  # type: () -> bool
         return output.stdout != ""
     except subprocess.CalledProcessError:
         return False
-    
+ 
 
 def validate_smddpmprun():  # type: () -> bool
     """Whether smddpmprun is installed.

--- a/src/sagemaker_training/environment.py
+++ b/src/sagemaker_training/environment.py
@@ -359,6 +359,24 @@ def num_cpus():  # type: () -> int
     return multiprocessing.cpu_count()
 
 
+def validate_smddprun():  # type: () -> bool
+    """Whether smddprun is installed.
+
+    Returns:
+        bool: True if installed
+    """
+    try:
+        output = subprocess.run(
+            ["which", "smddprun"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return output.stdout != ""
+    except subprocess.CalledProcessError:
+        return False
+    
+
 def validate_smddpmprun():  # type: () -> bool
     """Whether smddpmprun is installed.
 
@@ -669,6 +687,7 @@ class Environment(mapping.MappingMixin):  # pylint:disable=too-many-public-metho
 
         mp_parameters = os.environ.get(params.SM_HP_MP_PARAMETERS)
         self._is_modelparallel_enabled = mp_parameters and mp_parameters != "{}"
+        self._is_smddprun_installed = validate_smddprun()
         self._is_smddpmprun_installed = validate_smddpmprun()
 
     @property

--- a/src/sagemaker_training/environment.py
+++ b/src/sagemaker_training/environment.py
@@ -1228,7 +1228,7 @@ class Environment(mapping.MappingMixin):  # pylint:disable=too-many-public-metho
         return self._is_smddpmprun_installed
 
     @property
-    def is_smddprun_installed(self): # type: () -> bool
+    def is_smddprun_installed(self):  # type: () -> bool
         """Whether smddprun is installed.
 
         Returns:

--- a/src/sagemaker_training/environment.py
+++ b/src/sagemaker_training/environment.py
@@ -375,7 +375,7 @@ def validate_smddprun():  # type: () -> bool
         return output.stdout != ""
     except subprocess.CalledProcessError:
         return False
- 
+
 
 def validate_smddpmprun():  # type: () -> bool
     """Whether smddpmprun is installed.

--- a/src/sagemaker_training/smdataparallel.py
+++ b/src/sagemaker_training/smdataparallel.py
@@ -230,11 +230,7 @@ class SMDataParallelRunner(process.ProcessRunner):
                 ]
             )
 
-        smddp_supported_instances = [
-            "ml.p4d.24xlarge",
-            "ml.p4de.24xlarge"
-        ]
-        if env.is_smddprun_installed and instance_type in smddp_supported_instances:
+        if env.is_smddprun_installed:
             smddprun_command = ["smddprun"]
             mpirun_command.extend(smddprun_command)
         return mpirun_command

--- a/src/sagemaker_training/smdataparallel.py
+++ b/src/sagemaker_training/smdataparallel.py
@@ -231,6 +231,9 @@ class SMDataParallelRunner(process.ProcessRunner):
         if env.is_smddprun_installed:
             smddprun_command = ["smddprun"]
             mpirun_command.extend(smddprun_command)
+        else:
+            print(f"Warning: smddprun not being used as smddp is not installed")
+
         return mpirun_command
 
     def _get_instance_type(self):

--- a/src/sagemaker_training/smdataparallel.py
+++ b/src/sagemaker_training/smdataparallel.py
@@ -232,7 +232,7 @@ class SMDataParallelRunner(process.ProcessRunner):
             smddprun_command = ["smddprun"]
             mpirun_command.extend(smddprun_command)
         else:
-            print(f"Warning: smddprun not being used as smddp is not installed")
+            print("Warning: smddprun not being used as smddp is not installed")
 
         return mpirun_command
 

--- a/src/sagemaker_training/smdataparallel.py
+++ b/src/sagemaker_training/smdataparallel.py
@@ -136,8 +136,6 @@ class SMDataParallelRunner(process.ProcessRunner):
             )
             raise
 
-
-
     def _get_mpirun_command(
         self,
         num_hosts,

--- a/src/sagemaker_training/smdataparallel.py
+++ b/src/sagemaker_training/smdataparallel.py
@@ -136,6 +136,8 @@ class SMDataParallelRunner(process.ProcessRunner):
             )
             raise
 
+
+
     def _get_mpirun_command(
         self,
         num_hosts,
@@ -149,7 +151,7 @@ class SMDataParallelRunner(process.ProcessRunner):
         overridden_known_options, additional_options = _parse_custom_mpi_options(
             self._custom_mpi_options
         )
-
+        env = environment.Environment()
         mpirun_command = [
             "mpirun",
             "--host",
@@ -228,8 +230,13 @@ class SMDataParallelRunner(process.ProcessRunner):
                 ]
             )
 
-        smddprun_command = ["smddprun"]
-        mpirun_command.extend(smddprun_command)
+        smddp_supported_instances = [
+            "ml.p4d.24xlarge",
+            "ml.p4de.24xlarge"
+        ]
+        if env.is_smddprun_installed and instance_type in smddp_supported_instances:
+            smddprun_command = ["smddprun"]
+            mpirun_command.extend(smddprun_command)
         return mpirun_command
 
     def _get_instance_type(self):

--- a/test/unit/test_environment.py
+++ b/test/unit/test_environment.py
@@ -285,6 +285,7 @@ def test_env_mapping_properties(training_env):
         "distribution_instance_groups",
         "is_hetero",
         "is_smddpmprun_installed",
+        "is_smddprun_installed",
     }
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Herring will not be installed on P5 targeted DLCs in the near future, making the smddprun script unavailable.  Thus in this PR, we check whether smddprun is installed and only then append it to the run command in the smdistributed launcher script.  smddprun is only used to set environment variables for Herring jobs so it should not affect ability to run non-Herring jobs with this launcher.  

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

Verified with local testing that smddprun is correctly appended to the run command when it is installed in the environment, and it is not appended (and a warning message is printed) when smddprun is not present.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
