### PR TITLE
change: update the boto deps to use latest boto

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,8 @@ required_packages = [
     "psutil>=5.6.7",
     "protobuf>=3.9.2,<=3.20.3",
     "scipy>=1.2.2",
-    "boto3==1.28.57",
-    "botocore==1.31.57",
+    "boto3>=1.28.57",
+    "botocore>=1.31.57",
 ]
 
 # enum is introduced in Python 3.4. Installing enum back port


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Pinned versions of boto/botocore does not allow pulling the latest training toolkit version in DLC images

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
