### PR TITLE
feature: add python module entrypoint type, add python module support…

### DIFF
--- a/src/sagemaker_training/_entry_point_type.py
+++ b/src/sagemaker_training/_entry_point_type.py
@@ -21,11 +21,13 @@ import os
 class _EntryPointType(enum.Enum):
     """Enumerated type consisting of valid types of training entry points."""
 
+    PYTHON_MODULE = "PYTHON_MODULE"
     PYTHON_PACKAGE = "PYTHON_PACKAGE"
     PYTHON_PROGRAM = "PYTHON_PROGRAM"
     COMMAND = "COMMAND"
 
 
+PYTHON_MODULE = _EntryPointType.PYTHON_MODULE
 PYTHON_PACKAGE = _EntryPointType.PYTHON_PACKAGE
 PYTHON_PROGRAM = _EntryPointType.PYTHON_PROGRAM
 COMMAND = _EntryPointType.COMMAND
@@ -46,5 +48,7 @@ def get(path, name):  # type: (str, str) -> _EntryPointType
         return _EntryPointType.PYTHON_PACKAGE
     elif name.endswith(".py"):
         return _EntryPointType.PYTHON_PROGRAM
+    elif name.startswith("-m "):
+        return _EntryPointType.PYTHON_MODULE
     else:
         return _EntryPointType.COMMAND

--- a/src/sagemaker_training/torch_distributed.py
+++ b/src/sagemaker_training/torch_distributed.py
@@ -93,7 +93,7 @@ class TorchDistributedRunner(process.ProcessRunner):
                 "Please use a python script as the entry-point"
             )
 
-        if entrypoint_type is _entry_point_type.PYTHON_PROGRAM:
+        if entrypoint_type is _entry_point_type.PYTHON_PROGRAM or entrypoint_type is _entry_point_type.PYTHON_MODULE:
             num_hosts = len(self._hosts)
             torchrun_cmd = []
 
@@ -135,7 +135,7 @@ class TorchDistributedRunner(process.ProcessRunner):
             torchrun_cmd += self._args
             return torchrun_cmd
         else:
-            raise errors.ClientError("Unsupported entry point type for torch_distributed")
+            raise errors.ClientError(f"Unsupported entry point type for torch_distributed: {entrypoint_type}")
 
     def run(self, capture_error=True, wait=True):
         """

--- a/test/unit/test_entry_point_type.py
+++ b/test/unit/test_entry_point_type.py
@@ -36,6 +36,10 @@ def has_requirements():
         yield
 
 
+def test_get_module():
+    assert _entry_point_type.get("bla", "-m program") == _entry_point_type.PYTHON_MODULE
+
+
 def test_get_package(entry_point_type_module):
     assert _entry_point_type.get("bla", "program.py") == _entry_point_type.PYTHON_PACKAGE
 


### PR DESCRIPTION
*Issue #, if available:*

Related to https://github.com/aws/sagemaker-python-sdk/pull/4324

*Description of changes:*
`torchrun` can run modules via `-m <MODULE` but SageMaker runtime does not yet support this entrypoint type. Adding a new entrypoint type and add support to torch_distributed.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.