### PR TITLE
chore: removing unnecessary logging information

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -17,7 +17,7 @@ phases:
       # run unit tests
       - AWS_ACCESS_KEY_ID= AWS_SECRET_ACCESS_KEY= AWS_SESSION_TOKEN=
         AWS_CONTAINER_CREDENTIALS_RELATIVE_URI= AWS_DEFAULT_REGION=
-        tox -v -e py38,py39,py310 --parallel all -- test/unit
+        tox -v -e py38,py39,py310 -- test/unit
 
       # build toolkit
       - python setup.py sdist

--- a/src/sagemaker_training/modules.py
+++ b/src/sagemaker_training/modules.py
@@ -148,7 +148,7 @@ def install_requirements(path, capture_error=False):  # type: (str, bool) -> Non
         index = _get_codeartifact_index()
         cmd += " -i {}".format(index)
 
-    logger.info("Installing dependencies from requirements.txt:\n{}".format(cmd))
+    logger.info("Installing dependencies from requirements.txt")
 
     process.check_error(
         shlex.split(cmd), errors.InstallRequirementsError, 1, cwd=path, capture_error=capture_error

--- a/src/sagemaker_training/modules.py
+++ b/src/sagemaker_training/modules.py
@@ -128,7 +128,7 @@ def install(path, capture_error=False):  # type: (str, bool) -> None
             index = _get_codeartifact_index()
             cmd += " -i {}".format(index)
 
-    logger.info("Installing module with the following command:\n%s", cmd)
+    logger.info("Installing module.")
 
     process.check_error(
         shlex.split(cmd), errors.InstallModuleError, 1, cwd=path, capture_error=capture_error

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,8 @@ commands =
 
 deps =
     pytest==6.2.5
-    pytest-cov
+    coverage>=5.2, <6.2
+    pytest-cov==3.0.0
     pytest-xdist
     pytest-asyncio
     mock

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = black-format,flake8,pylint,twine,py39,py310
+envlist = black-format,flake8,pylint,twine,py38,py39,py310
 
 skip_missing_interpreters = False
 

--- a/tox.ini
+++ b/tox.ini
@@ -44,8 +44,8 @@ commands =
 
 deps =
     pytest==6.2.5
-    coverage>=5.2, <6.2
-    pytest-cov==3.0.0
+    coverage
+    pytest-cov
     pytest-xdist
     pytest-asyncio
     mock


### PR DESCRIPTION
*Description of changes:*
- Removing unnecessary logging information
- Change ```buildspec.yml``` to not run tests in parallel as it cause flaky .coverage data file issue

*Testing done:*
Ran ```tox /test/unit``` locally and confirmed all unit tests passed:

```
___________________________________ summary ____________________________________
  black-format: commands succeeded
  flake8: commands succeeded
  pylint: commands succeeded
  twine: commands succeeded
  py38: commands succeeded
  py39: commands succeeded
  py310: commands succeeded
  congratulations :)
```

Don't have py310 setup in my local environment but it should be fine

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
