### PR TITLE
fix: typo in the run unit tests command

### DIFF
--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -19,7 +19,7 @@ phases:
       # run unit tests
       - AWS_ACCESS_KEY_ID= AWS_SECRET_ACCESS_KEY= AWS_SESSION_TOKEN=
         AWS_CONTAINER_CREDENTIALS_RELATIVE_URI= AWS_DEFAULT_REGION=
-        tox -e py38,py39,py310 all -- test/unit
+        tox -e py38,py39,py310 -- test/unit
 
       # run functional tests
       - $(aws ecr get-login --no-include-email --region us-west-2)


### PR DESCRIPTION
*Description of changes:*
typo in the run unit tests command. ```all``` makes unit tests failed

*Testing done:*
Ran ```tox -e py38,py39,py310 -- test/unit``` and got
```
  py38: commands succeeded
  py39: commands succeeded
  py310: commands succeeded
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
