### PR TITLE
feature: Add p5 as a supported NCCL instance

### DIFF
--- a/src/sagemaker_training/__init__.py
+++ b/src/sagemaker_training/__init__.py
@@ -81,6 +81,7 @@ SM_EFA_NCCL_INSTANCES = [
     "ml.p3dn.24xlarge",
     "ml.p4d.24xlarge",
     "ml.p4de.24xlarge",
+    "ml.p5.48xlarge",
     "ml.trn1.32xlarge",
 ]
 


### PR DESCRIPTION
*Issue #, if available:* 219

*Description of changes:* Add "ml.p5.48xlarge" to SM_EFA_NCCL_INSTANCES. This will automatically set the FI_PROVIDER environment variable to "efa".

*Testing done:* NA

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
