### PR TITLE
Fix: Preserve hyperparameter order when invoking training jobs

### DIFF
--- a/src/sagemaker_training/mapping.py
+++ b/src/sagemaker_training/mapping.py
@@ -75,7 +75,7 @@ def to_cmd_args(mapping):  # type: (dict) -> list
         (list): List of cmd arguments.
     """
 
-    sorted_keys = sorted(mapping.keys())
+    mapping_keys = mapping.keys()
 
     def arg_name(obj):
         string = _decode(obj)
@@ -84,15 +84,15 @@ def to_cmd_args(mapping):  # type: (dict) -> list
         else:
             return ""
 
-    arg_names = [arg_name(argument) for argument in sorted_keys]
+    arg_names = [arg_name(argument) for argument in mapping_keys]
 
     def arg_value(value):
         if hasattr(value, "items"):
-            map_items = ["%s=%s" % (k, v) for k, v in sorted(value.items())]
+            map_items = ["%s=%s" % (k, v) for k, v in value.items()]
             return ",".join(map_items)
         return _decode(value)
 
-    arg_values = [arg_value(mapping[key]) for key in sorted_keys]
+    arg_values = [arg_value(mapping[key]) for key in mapping_keys]
 
     items = zip(arg_names, arg_values)
 

--- a/test/unit/test_mapping.py
+++ b/test/unit/test_mapping.py
@@ -102,21 +102,21 @@ def test_mapping_throws_exception_trying_to_access_non_properties(property, erro
     [
         (
             {"da-sh": "1", "un_der": "2", "un-sh": "3", "da_der": "2"},
-            ["--da-sh", "1", "--da_der", "2", "--un-sh", "3", "--un_der", "2"],
+            ["--da-sh", "1", "--un_der", "2", "--un-sh", "3", "--da_der", "2"],
         ),
         ({}, []),
         ({"": ""}, ["", ""]),
         (
             {"unicode": "¡ø", "bytes": b"2", "floats": 4.0, "int": 2},
-            ["--bytes", "2", "--floats", "4.0", "--int", "2", "--unicode", "¡ø"],
+            ["--unicode", "¡ø", "--bytes", "2", "--floats", "4.0", "--int", "2"],
         ),
-        ({"U": "1", "b": b"2", "T": "", "": "42"}, ["", "42", "-T", "", "-U", "1", "-b", "2"]),
+        ({"U": "1", "b": b"2", "T": "", "": "42"}, ["-U", "1", "-b", "2", "-T", "", "", "42" ]),
         ({"nested": ["1", ["2", "3", [["6"]]]]}, ["--nested", "['1', ['2', '3', [['6']]]]"]),
         (
             {"map": {"a": [1, 3, 4]}, "channel_dirs": {"train": "foo", "eval": "bar"}},
-            ["--channel_dirs", "eval=bar,train=foo", "--map", "a=[1, 3, 4]"],
+            ["--map", "a=[1, 3, 4]", "--channel_dirs", "train=foo,eval=bar"],
         ),
-        ({"truthy": True, "falsy": False}, ["--falsy", "False", "--truthy", "True"]),
+        ({"truthy": True, "falsy": False}, ["--truthy", "True", "--falsy", "False"]),
     ],
 )
 def test_to_cmd_args(target, expected):
@@ -218,7 +218,7 @@ def test_env_vars_round_trip():
     )
     assert env_vars["SM_MODULE_NAME"] == "user_script"
     assert env_vars["SM_INPUT_CONFIG_DIR"].endswith("/opt/ml/input/config")
-    assert env_vars["SM_USER_ARGS"] == "--batch_size 64 --epochs 10 --loss SGD --precision 5.434322"
+    assert env_vars["SM_USER_ARGS"] == "--loss SGD --epochs 10 --batch_size 64 --precision 5.434322"
     assert env_vars["SM_OUTPUT_DIR"].endswith("/opt/ml/output")
     assert env_vars["SM_MODEL_DIR"].endswith("/opt/ml/model")
     assert env_vars["SM_HOSTS"] == '["algo-1","algo-2","algo-3"]'


### PR DESCRIPTION
Fixes https://github.com/aws/sagemaker-training-toolkit/issues/221.

Removed the alphanumeric sorting of the hyperparameters in

https://github.com/aws/sagemaker-training-toolkit/blob/628166c157751ae2a46fddc11a7a8cac765fb22c/src/sagemaker_training/mapping.py#L65-L78

This makes sure that training scripts are invoked with the same order of hyperparameters as passed in the `hyperparameters` argument to the SageMaker `Estimator` class. This sorting was undocumented and as argued in issue https://github.com/aws/sagemaker-training-toolkit/issues/221 can cause issues for scripts where order of the arguments matters.

I have updated the unit tests in `test_mapping.py` to verify that the order of the arguments is preserved.

I ran the unit tests with `tox -e py310 -- -s -vv test/unit` and they passed. Let's see if the CI tests find anything...

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
