### PR TITLE
fix: temporarily hardcode neuron cores for trn2

### DIFF
--- a/src/sagemaker_training/environment.py
+++ b/src/sagemaker_training/environment.py
@@ -299,19 +299,23 @@ def channel_path(channel):  # type: (str) -> str
     return os.path.join(_input_data_dir, channel)
 
 
-def num_neurons():  # type: () -> int
+def num_neurons(instance_type):  # type: (str) -> int
     """Return the number of neuron cores available in the current container.
 
     Returns:
         int: Number of Neuron Cores available in the current container.
     """
     try:
-        cmd = shlex.split("neuron-ls -j")
-        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode("utf-8")
-        j = json.loads(output)
-        neuron_cores = 0
-        for item in j:
-            neuron_cores += item.get("nc_count", 0)
+        if "trn2.48xlarge" in instance_type:
+            logger.info("Check number of neuron cores in trn2")
+            neuron_cores = 64
+        else:
+            cmd = shlex.split("neuron-ls -j")
+            output = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode("utf-8")
+            j = json.loads(output)
+            neuron_cores = 0
+            for item in j:
+                neuron_cores += item.get("nc_count", 0)
         logger.info(f"Found {neuron_cores} neurons on this instance")
         return neuron_cores
     except OSError:
@@ -584,7 +588,6 @@ class Environment(mapping.MappingMixin):  # pylint:disable=too-many-public-metho
 
         self._num_gpus = num_gpus()
         self._num_cpus = num_cpus()
-        self._num_neurons = num_neurons()
         self._module_name = module_name
         self._user_entry_point = module_name
         self._module_dir = module_dir
@@ -599,6 +602,8 @@ class Environment(mapping.MappingMixin):  # pylint:disable=too-many-public-metho
         current_instance_type = resource_config.get("current_instance_type", "local")
         current_instance_group = resource_config.get("current_group_name", "homogeneousCluster")
         current_host = resource_config["current_host"]
+
+        self._num_neurons = num_neurons(current_instance_type)
 
         self._current_host = current_host
         self._current_instance_type = current_instance_type

--- a/src/sagemaker_training/environment.py
+++ b/src/sagemaker_training/environment.py
@@ -307,7 +307,6 @@ def num_neurons(instance_type):  # type: (str) -> int
     """
     try:
         if "trn2.48xlarge" in instance_type:
-            logger.info("Check number of neuron cores in trn2")
             neuron_cores = 64
         else:
             cmd = shlex.split("neuron-ls -j")

--- a/test/unit/test_environment.py
+++ b/test/unit/test_environment.py
@@ -144,12 +144,16 @@ def test_gpu_count_in_cpu_instance(check_output):
 
 @patch("subprocess.check_output", lambda s, stderr: b'[{"nc_count":2}]')
 def test_neuron_count_in_neuron_instance():
-    assert environment.num_neurons() == 2
+    assert environment.num_neurons("dummy-instance-type") == 2
 
 
 @patch("subprocess.check_output", side_effect=OSError())
 def test_neuron_count_in_cpu_instance(check_output):
-    assert environment.num_neurons() == 0
+    assert environment.num_neurons("dummy-instance-type") == 0
+
+
+def test_neuron_count_in_trn2_instance():
+    assert environment.num_neurons("ml.trn2.48xlarge") == 64
 
 
 @patch(
@@ -159,7 +163,7 @@ def test_neuron_count_in_cpu_instance(check_output):
     ),
 )
 def test_neuron_count_in_neuron_instance_nodriver(check_output):
-    assert environment.num_neurons() == 0
+    assert environment.num_neurons("dummy-instance-type") == 0
 
 
 @patch(
@@ -171,7 +175,7 @@ def test_neuron_count_in_neuron_instance_nodriver(check_output):
     ),
 )
 def test_neuron_count_in_neuron_instance_nodriver_with_error_msg(check_output):
-    assert environment.num_neurons() == 0
+    assert environment.num_neurons("dummy-instance-type") == 0
 
 
 @patch("multiprocessing.cpu_count", lambda: 2)
@@ -194,7 +198,7 @@ def create_training_env():
     ), patch(
         "sagemaker_training.environment.num_gpus", lambda: 4
     ), patch(
-        "sagemaker_training.environment.num_neurons", lambda: 2
+        "sagemaker_training.environment.num_neurons", lambda instance_type: 2
     ):
         session_mock = Mock()
         session_mock.region_name = "us-west-2"
@@ -291,7 +295,7 @@ def test_env_mapping_properties(training_env):
 
 @patch("sagemaker_training.environment.num_cpus", lambda: 8)
 @patch("sagemaker_training.environment.num_gpus", lambda: 4)
-@patch("sagemaker_training.environment.num_neurons", lambda: 2)
+@patch("sagemaker_training.environment.num_neurons", lambda instance_type: 2)
 def test_env_dictionary():
     session_mock = Mock()
     session_mock.region_name = "us-west-2"


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
- This is needed to support the upcoming EC2 trn2.48xlarge release. Otherwise, jobs trying to use trn2 will fail (confirmed through testing).
- Checked with Neuron team that the # of Neuron cores in trn2 is 64, so it is hardcoded for now. Neuron team confirmed they will release `lnc_count` which will work for trn2 but to immediately unblock trn2 release, we need this change. We can remove this after their fix is released.

*Testing done:* Updated + added unit tests, `tox test/unit` passed.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
