### PR TITLE
Fix unknown argument: '-export-dynamic' macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,9 +52,12 @@ if sys.version_info < (3, 4):
 
 gethostname = setuptools.Extension(
     "gethostname",
-    sources=["src/sagemaker_training/c/gethostname.c", "src/sagemaker_training/c/jsmn.c"],
+    sources=[
+        "src/sagemaker_training/c/gethostname.c",
+        "src/sagemaker_training/c/jsmn.c",
+    ],
     include_dirs=["src/sagemaker_training/c"],
-    extra_compile_args=["-Wall", "-shared", "-export-dynamic", "-ldl"],
+    extra_compile_args=["-Wall", "-shared", "-Wl,-export-dynamic", "-ldl"],
 )
 
 setuptools.setup(
@@ -63,7 +66,9 @@ setuptools.setup(
     description="Open source library for creating containers to run on Amazon SageMaker.",
     packages=packages,
     package_dir={"sagemaker_training": "src/sagemaker_training"},
-    py_modules=[os.path.splitext(os.path.basename(path))[0] for path in glob("src/*.py")],
+    py_modules=[
+        os.path.splitext(os.path.basename(path))[0] for path in glob("src/*.py")
+    ],
     ext_modules=[gethostname],
     long_description=read("README.md"),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
*Issue #225*

*Description of changes:* Add '-Wl' to instruct clang (default compiler on macOs) to forward argument to linker phase.

*Testing done:* Manual install via `pip install .` on macOS Sonoma 14.7.1 and Debian bookworm (gcc) and through the unit test with `tox -e py39 -- -s -vv test/unit/test_entry_point.py::test_install_module` in macOS and `tox -e py310 -- -s -vv test/unit/test_entry_point.py::test_install_module` in Debian.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
