### PR TITLE
fix: avoid parsing stderr as JSON

### DIFF
--- a/src/sagemaker_training/environment.py
+++ b/src/sagemaker_training/environment.py
@@ -307,7 +307,7 @@ def num_neurons():  # type: () -> int
     """
     try:
         cmd = shlex.split("neuron-ls -j")
-        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode("utf-8")
+        output = subprocess.check_output(cmd).decode("utf-8")
         j = json.loads(output)
         neuron_cores = 0
         for item in j:


### PR DESCRIPTION
*Issue #:* P174559933

*Description of changes:* Parsing stderr as JSON is a bad practice and caused issue P174559933. This change ensures proper handling of output to prevent similar issues in the future.


*Testing done:* None

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
