### PR TITLE
fix: resolve failing unit test

### DIFF
--- a/test/unit/test_environment.py
+++ b/test/unit/test_environment.py
@@ -142,7 +142,7 @@ def test_gpu_count_in_cpu_instance(check_output):
     assert environment.num_gpus() == 0
 
 
-@patch("subprocess.check_output", lambda s, stderr: b'[{"nc_count":2}]')
+@patch("subprocess.check_output", lambda s, stderr=None: b'[{"nc_count":2}]')
 def test_neuron_count_in_neuron_instance():
     assert environment.num_neurons("dummy-instance-type") == 2
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- The latest change merged into training toolkit broke the unit tests and thus cannot release successfully. The root cause is that in the `num_neurons` method, previously `stderr` was provided the explicit `subprocess.STDOUT` arg - so we need to update the mock to subprocess.check_output to pass in something for stderr.

*Testing done:*
Reran the failed test using `tox` with this code change and it passed.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
