### PR TITLE
fix: account for possible race condition when creating /opt/ml/code

### DIFF
--- a/src/sagemaker_training/environment.py
+++ b/src/sagemaker_training/environment.py
@@ -183,7 +183,10 @@ if not _is_path_configured:
 def _create_code_dir():  # type: () -> None
     """Create /opt/ml/code when the module is imported."""
     if not os.path.exists(code_dir):
-        os.makedirs(code_dir)
+        try:
+            os.makedirs(code_dir)
+        except FileExistsError:
+            pass  # Another process created the directory
 
 
 _create_code_dir()


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/sagemaker-python-sdk/issues/5012

*Description of changes:*
When using ModelTrainer to run Distributed training with hyperpod recipes sometimes see error like `[Errno 17] File exists: '/opt/ml/code'` due to race condition when multiple processes execute [_create_code_dir](https://github.com/aws/sagemaker-training-toolkit/blob/874f7b055eba3cf3a599b6c5ef74c40396bc9376/src/sagemaker_training/environment.py#L189)

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-training-toolkit/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-training-toolkit/blob/master/README.md)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
