### PR TITLE
Adding useful logging info for sourcedir logic

### DIFF
--- a/src/sagemaker_training/files.py
+++ b/src/sagemaker_training/files.py
@@ -132,6 +132,7 @@ def download_and_extract(uri, path):  # type: (str, str) -> None
     if not os.path.exists(path):
         os.makedirs(path)
     if not os.listdir(path):
+        logger.info(f"Provided path: {path}  is empty, unzipping")
         with tmpdir() as tmp:
             if uri.startswith("s3://"):
                 dst = os.path.join(tmp, "tar_file")
@@ -151,6 +152,8 @@ def download_and_extract(uri, path):  # type: (str, str) -> None
                     t.extractall(path=path)
             else:
                 shutil.copy2(uri, path)
+    else:
+        logger.info(f"Provided path: {path} is not empty, abandoning unzipping sourcedir.tar.gz")
 
 
 def s3_download(url, dst):  # type: (str, str) -> None


### PR DESCRIPTION
After spending an afternoon trying to understand why my sourcedir files were not appearing in my custom container using sagemaker-training-toolkit. I realised that the toolkit will not unzip the sourcedir.tar.gz if files are already present in the path. There is not logging to indicate this to an end user which may be helpful for debugging. I have added some logging statements to aid in this.